### PR TITLE
Add `clear` and `assignVectorScalar`

### DIFF
--- a/graphblas-java/pom.xml
+++ b/graphblas-java/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.fabianmurariu</groupId>
     <artifactId>graphblas-java</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
     <packaging>nar</packaging>
 
     <name>GraphBLAS JNI Bindings</name>

--- a/graphblas-java/src/main/c/unsafe.c
+++ b/graphblas-java/src/main/c/unsafe.c
@@ -5,6 +5,12 @@
 #include <assert.h>
 long check_grb_error(GrB_Info info);
 
+JavaVM *javavm;
+
+JNIEXPORT jint JNICALL JNI_OnLoad (JavaVM *jvm, void *reserved) {
+    javavm=jvm;
+    return JNI_VERSION_1_2;
+}
             long check_grb_error(GrB_Info info)
             {
             if (! (info == GrB_SUCCESS || info == GrB_NO_VALUE))
@@ -22,12 +28,12 @@ long check_grb_error(GrB_Info info);
 
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_grbWait
             (JNIEnv * env, jclass cls) {
-            check_grb_error(GrB_wait());
+            return check_grb_error(GrB_wait());
             }
 
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_grbFinalize
             (JNIEnv * env, jclass cls) {
-            check_grb_error(GrB_finalize());
+            return check_grb_error(GrB_finalize());
             }
 
             JNIEXPORT jobject JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_createMatrix
@@ -36,8 +42,18 @@ long check_grb_error(GrB_Info info);
             GrB_Matrix A;
             GrB_Index mat_rows = (GrB_Index)rows;
             GrB_Index mat_cols = (GrB_Index)cols;
-            check_grb_error (GrB_Matrix_new(&A, grb_type, mat_rows, mat_cols) );
+
+            jclass err_cls;
+            GrB_Info err = check_grb_error (GrB_Matrix_new(&A, grb_type, mat_rows, mat_cols) );
+            if (err != 0) {
+               err_cls = (*env)->FindClass(env, "com/github/fabianmurariu/unsafe/GrBJNIException");
+               (*env)->ThrowNew(env, err_cls, (long)err);
+               goto done;
+            }
             return (*env)->NewDirectByteBuffer(env, A, 0);
+            done:
+                if (err_cls != NULL)
+                    (*env)->DeleteLocalRef(env, err_cls);
             }
 
             JNIEXPORT jobject JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_createVector
@@ -133,7 +149,7 @@ long check_grb_error(GrB_Info info);
             GrB_Matrix m = mask != NULL ? (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mask): NULL;
             GrB_Descriptor d = desc != NULL ? (GrB_Descriptor) (*env)->GetDirectBufferAddress(env, desc): NULL;
 
-            check_grb_error(GrB_Matrix_apply(A, m, a, op, first_mat, d));
+            return check_grb_error(GrB_Matrix_apply(A, m, a, op, first_mat, d));
             }
 
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_vectorApply
@@ -147,7 +163,7 @@ long check_grb_error(GrB_Info info);
             GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask): NULL;
             GrB_Descriptor d = desc != NULL ? (GrB_Descriptor) (*env)->GetDirectBufferAddress(env, desc): NULL;
 
-            check_grb_error(GrB_Vector_apply(A, m, a, op, first_vec, d));
+            return check_grb_error(GrB_Vector_apply(A, m, a, op, first_vec, d));
             }
 
 JNIEXPORT jobject JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_createSemiring
@@ -184,20 +200,20 @@ JNIEXPORT jobject JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_dupVector
 JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_makeCSC
   (JNIEnv * env, jclass cls, jobject mat) {
         GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
-        check_grb_error(GxB_Matrix_Option_set(A, GxB_FORMAT, GxB_BY_COL));
+        return check_grb_error(GxB_Matrix_Option_set(A, GxB_FORMAT, GxB_BY_COL));
   }
 
 JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_makeCSR
   (JNIEnv * env, jclass cls, jobject mat) {
         GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
-        check_grb_error(GxB_Matrix_Option_set(A, GxB_FORMAT, GxB_BY_ROW));
+        return check_grb_error(GxB_Matrix_Option_set(A, GxB_FORMAT, GxB_BY_ROW));
   }
 
 JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_setHyperRatio
   (JNIEnv * env, jclass cls, jobject mat, jdouble ratio) {
         GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
         double r = ratio;
-        check_grb_error(GxB_Matrix_Option_set(A, GxB_HYPER, r));
+        return check_grb_error(GxB_Matrix_Option_set(A, GxB_HYPER, r));
   }
 
 JNIEXPORT jdouble JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_getHyperRatio

--- a/graphblas-java/src/main/c/unsafe.c
+++ b/graphblas-java/src/main/c/unsafe.c
@@ -106,6 +106,18 @@ JNIEXPORT jint JNICALL JNI_OnLoad (JavaVM *jvm, void *reserved) {
             return (jlong)n;
             }
 
+            JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_clearVec
+            (JNIEnv * env, jclass cls, jobject vec) {
+            GrB_Vector V = (GrB_Vector) (*env)->GetDirectBufferAddress(env, vec);
+            return check_grb_error(GrB_Vector_clear(V));
+            }
+
+             JNIEXPORT long JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_clearMatrix
+             (JNIEnv * env, jclass cls, jobject mat) {
+             GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
+             return check_grb_error(GrB_Matrix_clear(A) );
+             }
+
             JNIEXPORT long JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_freeMatrix
             (JNIEnv * env, jclass cls, jobject mat) {
             GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);

--- a/graphblas-java/src/main/c/unsafe_gen.c
+++ b/graphblas-java/src/main/c/unsafe_gen.c
@@ -1279,26 +1279,20 @@ long check_grb_error(GrB_Info info);
 
                 // !DIFFERENCE: ni == vector size -> GrB_ALL .. as no way to get pointer to GrB_ALL object in java
                 GrB_Index* I = NULL;
-                GrB_Index assign_ni = (GrB_Index) ni;
+                GrB_Index grb_ni = (GrB_Index) ni;
+                jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                long java_min = -9223372036854775808;
 
-                GrB_Index vectorSize;
-                check_grb_error(GrB_Vector_size(&vectorSize, w));
-
-
-
-                if (vectorSize == assign_ni || is == NULL) {
+                if (java_is[0] == java_min) {
                     I = GrB_ALL;
                 }
                 else {
-                    jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                    I = malloc (assign_ni * sizeof (GrB_Index));
+                    I = malloc (grb_ni * sizeof (GrB_Index));
 
                     // just copy :(
-                    for (int i = 0; i < assign_ni; i++) {
+                    for (int i = 0; i < grb_ni; i++) {
                         I[i] = (GrB_Index)java_is[i];
                     }
-
-                    (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 }
 
                 // OPTIONAL STUFF
@@ -1307,8 +1301,9 @@ long check_grb_error(GrB_Info info);
                 GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL;
 
 
-                long res = check_grb_error(GrB_Vector_assign_BOOL(w, m, acc, value, I, assign_ni, d));
+                long res = check_grb_error(GrB_Vector_assign_BOOL(w, m, acc, value, I, grb_ni, d));
 
+                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 if(I != GrB_ALL) {
                     free(I);
                 }
@@ -1325,26 +1320,20 @@ long check_grb_error(GrB_Info info);
 
                 // !DIFFERENCE: ni == vector size -> GrB_ALL .. as no way to get pointer to GrB_ALL object in java
                 GrB_Index* I = NULL;
-                GrB_Index assign_ni = (GrB_Index) ni;
+                GrB_Index grb_ni = (GrB_Index) ni;
+                jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                long java_min = -9223372036854775808;
 
-                GrB_Index vectorSize;
-                check_grb_error(GrB_Vector_size(&vectorSize, w));
-
-
-
-                if (vectorSize == assign_ni || is == NULL) {
+                if (java_is[0] == java_min) {
                     I = GrB_ALL;
                 }
                 else {
-                    jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                    I = malloc (assign_ni * sizeof (GrB_Index));
+                    I = malloc (grb_ni * sizeof (GrB_Index));
 
                     // just copy :(
-                    for (int i = 0; i < assign_ni; i++) {
+                    for (int i = 0; i < grb_ni; i++) {
                         I[i] = (GrB_Index)java_is[i];
                     }
-
-                    (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 }
 
                 // OPTIONAL STUFF
@@ -1353,8 +1342,9 @@ long check_grb_error(GrB_Info info);
                 GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL;
 
 
-                long res = check_grb_error(GrB_Vector_assign_INT8(w, m, acc, value, I, assign_ni, d));
+                long res = check_grb_error(GrB_Vector_assign_INT8(w, m, acc, value, I, grb_ni, d));
 
+                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 if(I != GrB_ALL) {
                     free(I);
                 }
@@ -1371,26 +1361,20 @@ long check_grb_error(GrB_Info info);
 
                 // !DIFFERENCE: ni == vector size -> GrB_ALL .. as no way to get pointer to GrB_ALL object in java
                 GrB_Index* I = NULL;
-                GrB_Index assign_ni = (GrB_Index) ni;
+                GrB_Index grb_ni = (GrB_Index) ni;
+                jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                long java_min = -9223372036854775808;
 
-                GrB_Index vectorSize;
-                check_grb_error(GrB_Vector_size(&vectorSize, w));
-
-
-
-                if (vectorSize == assign_ni || is == NULL) {
+                if (java_is[0] == java_min) {
                     I = GrB_ALL;
                 }
                 else {
-                    jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                    I = malloc (assign_ni * sizeof (GrB_Index));
+                    I = malloc (grb_ni * sizeof (GrB_Index));
 
                     // just copy :(
-                    for (int i = 0; i < assign_ni; i++) {
+                    for (int i = 0; i < grb_ni; i++) {
                         I[i] = (GrB_Index)java_is[i];
                     }
-
-                    (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 }
 
                 // OPTIONAL STUFF
@@ -1399,8 +1383,9 @@ long check_grb_error(GrB_Info info);
                 GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL;
 
 
-                long res = check_grb_error(GrB_Vector_assign_INT16(w, m, acc, value, I, assign_ni, d));
+                long res = check_grb_error(GrB_Vector_assign_INT16(w, m, acc, value, I, grb_ni, d));
 
+                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 if(I != GrB_ALL) {
                     free(I);
                 }
@@ -1417,26 +1402,20 @@ long check_grb_error(GrB_Info info);
 
                 // !DIFFERENCE: ni == vector size -> GrB_ALL .. as no way to get pointer to GrB_ALL object in java
                 GrB_Index* I = NULL;
-                GrB_Index assign_ni = (GrB_Index) ni;
+                GrB_Index grb_ni = (GrB_Index) ni;
+                jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                long java_min = -9223372036854775808;
 
-                GrB_Index vectorSize;
-                check_grb_error(GrB_Vector_size(&vectorSize, w));
-
-
-
-                if (vectorSize == assign_ni || is == NULL) {
+                if (java_is[0] == java_min) {
                     I = GrB_ALL;
                 }
                 else {
-                    jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                    I = malloc (assign_ni * sizeof (GrB_Index));
+                    I = malloc (grb_ni * sizeof (GrB_Index));
 
                     // just copy :(
-                    for (int i = 0; i < assign_ni; i++) {
+                    for (int i = 0; i < grb_ni; i++) {
                         I[i] = (GrB_Index)java_is[i];
                     }
-
-                    (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 }
 
                 // OPTIONAL STUFF
@@ -1445,8 +1424,9 @@ long check_grb_error(GrB_Info info);
                 GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL;
 
 
-                long res = check_grb_error(GrB_Vector_assign_INT32(w, m, acc, value, I, assign_ni, d));
+                long res = check_grb_error(GrB_Vector_assign_INT32(w, m, acc, value, I, grb_ni, d));
 
+                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 if(I != GrB_ALL) {
                     free(I);
                 }
@@ -1463,26 +1443,20 @@ long check_grb_error(GrB_Info info);
 
                 // !DIFFERENCE: ni == vector size -> GrB_ALL .. as no way to get pointer to GrB_ALL object in java
                 GrB_Index* I = NULL;
-                GrB_Index assign_ni = (GrB_Index) ni;
+                GrB_Index grb_ni = (GrB_Index) ni;
+                jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                long java_min = -9223372036854775808;
 
-                GrB_Index vectorSize;
-                check_grb_error(GrB_Vector_size(&vectorSize, w));
-
-
-
-                if (vectorSize == assign_ni || is == NULL) {
+                if (java_is[0] == java_min) {
                     I = GrB_ALL;
                 }
                 else {
-                    jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                    I = malloc (assign_ni * sizeof (GrB_Index));
+                    I = malloc (grb_ni * sizeof (GrB_Index));
 
                     // just copy :(
-                    for (int i = 0; i < assign_ni; i++) {
+                    for (int i = 0; i < grb_ni; i++) {
                         I[i] = (GrB_Index)java_is[i];
                     }
-
-                    (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 }
 
                 // OPTIONAL STUFF
@@ -1491,8 +1465,9 @@ long check_grb_error(GrB_Info info);
                 GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL;
 
 
-                long res = check_grb_error(GrB_Vector_assign_INT64(w, m, acc, value, I, assign_ni, d));
+                long res = check_grb_error(GrB_Vector_assign_INT64(w, m, acc, value, I, grb_ni, d));
 
+                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 if(I != GrB_ALL) {
                     free(I);
                 }
@@ -1509,26 +1484,20 @@ long check_grb_error(GrB_Info info);
 
                 // !DIFFERENCE: ni == vector size -> GrB_ALL .. as no way to get pointer to GrB_ALL object in java
                 GrB_Index* I = NULL;
-                GrB_Index assign_ni = (GrB_Index) ni;
+                GrB_Index grb_ni = (GrB_Index) ni;
+                jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                long java_min = -9223372036854775808;
 
-                GrB_Index vectorSize;
-                check_grb_error(GrB_Vector_size(&vectorSize, w));
-
-
-
-                if (vectorSize == assign_ni || is == NULL) {
+                if (java_is[0] == java_min) {
                     I = GrB_ALL;
                 }
                 else {
-                    jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                    I = malloc (assign_ni * sizeof (GrB_Index));
+                    I = malloc (grb_ni * sizeof (GrB_Index));
 
                     // just copy :(
-                    for (int i = 0; i < assign_ni; i++) {
+                    for (int i = 0; i < grb_ni; i++) {
                         I[i] = (GrB_Index)java_is[i];
                     }
-
-                    (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 }
 
                 // OPTIONAL STUFF
@@ -1537,8 +1506,9 @@ long check_grb_error(GrB_Info info);
                 GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL;
 
 
-                long res = check_grb_error(GrB_Vector_assign_FP32(w, m, acc, value, I, assign_ni, d));
+                long res = check_grb_error(GrB_Vector_assign_FP32(w, m, acc, value, I, grb_ni, d));
 
+                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 if(I != GrB_ALL) {
                     free(I);
                 }
@@ -1555,26 +1525,20 @@ long check_grb_error(GrB_Info info);
 
                 // !DIFFERENCE: ni == vector size -> GrB_ALL .. as no way to get pointer to GrB_ALL object in java
                 GrB_Index* I = NULL;
-                GrB_Index assign_ni = (GrB_Index) ni;
+                GrB_Index grb_ni = (GrB_Index) ni;
+                jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                long java_min = -9223372036854775808;
 
-                GrB_Index vectorSize;
-                check_grb_error(GrB_Vector_size(&vectorSize, w));
-
-
-
-                if (vectorSize == assign_ni || is == NULL) {
+                if (java_is[0] == java_min) {
                     I = GrB_ALL;
                 }
                 else {
-                    jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                    I = malloc (assign_ni * sizeof (GrB_Index));
+                    I = malloc (grb_ni * sizeof (GrB_Index));
 
                     // just copy :(
-                    for (int i = 0; i < assign_ni; i++) {
+                    for (int i = 0; i < grb_ni; i++) {
                         I[i] = (GrB_Index)java_is[i];
                     }
-
-                    (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 }
 
                 // OPTIONAL STUFF
@@ -1583,8 +1547,9 @@ long check_grb_error(GrB_Info info);
                 GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL;
 
 
-                long res = check_grb_error(GrB_Vector_assign_FP64(w, m, acc, value, I, assign_ni, d));
+                long res = check_grb_error(GrB_Vector_assign_FP64(w, m, acc, value, I, grb_ni, d));
 
+                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 if(I != GrB_ALL) {
                     free(I);
                 }

--- a/graphblas-java/src/main/c/unsafe_gen.c
+++ b/graphblas-java/src/main/c/unsafe_gen.c
@@ -1271,6 +1271,329 @@ long check_grb_error(GrB_Info info);
                 }
 
 
+                JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_assignVectorBoolean
+                (JNIEnv * env, jclass cls, jobject vec, jobject mask, jobject accum, jboolean value,  jlongArray is, jlong ni, jobject desc) {
+
+                // NON OPTIONAL STUFF
+                GrB_Vector w = (GrB_Vector) (*env)->GetDirectBufferAddress(env, vec);
+
+                // !DIFFERENCE: ni == vector size -> GrB_ALL .. as no way to get pointer to GrB_ALL object in java
+                GrB_Index* I = NULL;
+                GrB_Index assign_ni = (GrB_Index) ni;
+
+                GrB_Index vectorSize;
+                check_grb_error(GrB_Vector_size(&vectorSize, w));
+
+
+
+                if (vectorSize == assign_ni || is == NULL) {
+                    I = GrB_ALL;
+                }
+                else {
+                    jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                    I = malloc (assign_ni * sizeof (GrB_Index));
+
+                    // just copy :(
+                    for (int i = 0; i < assign_ni; i++) {
+                        I[i] = (GrB_Index)java_is[i];
+                    }
+
+                    (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                }
+
+                // OPTIONAL STUFF
+                GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;
+                GrB_Descriptor d = desc != NULL ? (GrB_Descriptor) (*env)->GetDirectBufferAddress(env, desc) : NULL;
+                GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL;
+
+
+                long res = check_grb_error(GrB_Vector_assign_BOOL(w, m, acc, value, I, assign_ni, d));
+
+                if(I != GrB_ALL) {
+                    free(I);
+                }
+
+                return res;
+                }
+
+
+                JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_assignVectorByte
+                (JNIEnv * env, jclass cls, jobject vec, jobject mask, jobject accum, jbyte value,  jlongArray is, jlong ni, jobject desc) {
+
+                // NON OPTIONAL STUFF
+                GrB_Vector w = (GrB_Vector) (*env)->GetDirectBufferAddress(env, vec);
+
+                // !DIFFERENCE: ni == vector size -> GrB_ALL .. as no way to get pointer to GrB_ALL object in java
+                GrB_Index* I = NULL;
+                GrB_Index assign_ni = (GrB_Index) ni;
+
+                GrB_Index vectorSize;
+                check_grb_error(GrB_Vector_size(&vectorSize, w));
+
+
+
+                if (vectorSize == assign_ni || is == NULL) {
+                    I = GrB_ALL;
+                }
+                else {
+                    jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                    I = malloc (assign_ni * sizeof (GrB_Index));
+
+                    // just copy :(
+                    for (int i = 0; i < assign_ni; i++) {
+                        I[i] = (GrB_Index)java_is[i];
+                    }
+
+                    (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                }
+
+                // OPTIONAL STUFF
+                GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;
+                GrB_Descriptor d = desc != NULL ? (GrB_Descriptor) (*env)->GetDirectBufferAddress(env, desc) : NULL;
+                GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL;
+
+
+                long res = check_grb_error(GrB_Vector_assign_INT8(w, m, acc, value, I, assign_ni, d));
+
+                if(I != GrB_ALL) {
+                    free(I);
+                }
+
+                return res;
+                }
+
+
+                JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_assignVectorShort
+                (JNIEnv * env, jclass cls, jobject vec, jobject mask, jobject accum, jshort value,  jlongArray is, jlong ni, jobject desc) {
+
+                // NON OPTIONAL STUFF
+                GrB_Vector w = (GrB_Vector) (*env)->GetDirectBufferAddress(env, vec);
+
+                // !DIFFERENCE: ni == vector size -> GrB_ALL .. as no way to get pointer to GrB_ALL object in java
+                GrB_Index* I = NULL;
+                GrB_Index assign_ni = (GrB_Index) ni;
+
+                GrB_Index vectorSize;
+                check_grb_error(GrB_Vector_size(&vectorSize, w));
+
+
+
+                if (vectorSize == assign_ni || is == NULL) {
+                    I = GrB_ALL;
+                }
+                else {
+                    jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                    I = malloc (assign_ni * sizeof (GrB_Index));
+
+                    // just copy :(
+                    for (int i = 0; i < assign_ni; i++) {
+                        I[i] = (GrB_Index)java_is[i];
+                    }
+
+                    (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                }
+
+                // OPTIONAL STUFF
+                GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;
+                GrB_Descriptor d = desc != NULL ? (GrB_Descriptor) (*env)->GetDirectBufferAddress(env, desc) : NULL;
+                GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL;
+
+
+                long res = check_grb_error(GrB_Vector_assign_INT16(w, m, acc, value, I, assign_ni, d));
+
+                if(I != GrB_ALL) {
+                    free(I);
+                }
+
+                return res;
+                }
+
+
+                JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_assignVectorInt
+                (JNIEnv * env, jclass cls, jobject vec, jobject mask, jobject accum, jint value,  jlongArray is, jlong ni, jobject desc) {
+
+                // NON OPTIONAL STUFF
+                GrB_Vector w = (GrB_Vector) (*env)->GetDirectBufferAddress(env, vec);
+
+                // !DIFFERENCE: ni == vector size -> GrB_ALL .. as no way to get pointer to GrB_ALL object in java
+                GrB_Index* I = NULL;
+                GrB_Index assign_ni = (GrB_Index) ni;
+
+                GrB_Index vectorSize;
+                check_grb_error(GrB_Vector_size(&vectorSize, w));
+
+
+
+                if (vectorSize == assign_ni || is == NULL) {
+                    I = GrB_ALL;
+                }
+                else {
+                    jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                    I = malloc (assign_ni * sizeof (GrB_Index));
+
+                    // just copy :(
+                    for (int i = 0; i < assign_ni; i++) {
+                        I[i] = (GrB_Index)java_is[i];
+                    }
+
+                    (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                }
+
+                // OPTIONAL STUFF
+                GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;
+                GrB_Descriptor d = desc != NULL ? (GrB_Descriptor) (*env)->GetDirectBufferAddress(env, desc) : NULL;
+                GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL;
+
+
+                long res = check_grb_error(GrB_Vector_assign_INT32(w, m, acc, value, I, assign_ni, d));
+
+                if(I != GrB_ALL) {
+                    free(I);
+                }
+
+                return res;
+                }
+
+
+                JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_assignVectorLong
+                (JNIEnv * env, jclass cls, jobject vec, jobject mask, jobject accum, jlong value,  jlongArray is, jlong ni, jobject desc) {
+
+                // NON OPTIONAL STUFF
+                GrB_Vector w = (GrB_Vector) (*env)->GetDirectBufferAddress(env, vec);
+
+                // !DIFFERENCE: ni == vector size -> GrB_ALL .. as no way to get pointer to GrB_ALL object in java
+                GrB_Index* I = NULL;
+                GrB_Index assign_ni = (GrB_Index) ni;
+
+                GrB_Index vectorSize;
+                check_grb_error(GrB_Vector_size(&vectorSize, w));
+
+
+
+                if (vectorSize == assign_ni || is == NULL) {
+                    I = GrB_ALL;
+                }
+                else {
+                    jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                    I = malloc (assign_ni * sizeof (GrB_Index));
+
+                    // just copy :(
+                    for (int i = 0; i < assign_ni; i++) {
+                        I[i] = (GrB_Index)java_is[i];
+                    }
+
+                    (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                }
+
+                // OPTIONAL STUFF
+                GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;
+                GrB_Descriptor d = desc != NULL ? (GrB_Descriptor) (*env)->GetDirectBufferAddress(env, desc) : NULL;
+                GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL;
+
+
+                long res = check_grb_error(GrB_Vector_assign_INT64(w, m, acc, value, I, assign_ni, d));
+
+                if(I != GrB_ALL) {
+                    free(I);
+                }
+
+                return res;
+                }
+
+
+                JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_assignVectorFloat
+                (JNIEnv * env, jclass cls, jobject vec, jobject mask, jobject accum, jfloat value,  jlongArray is, jlong ni, jobject desc) {
+
+                // NON OPTIONAL STUFF
+                GrB_Vector w = (GrB_Vector) (*env)->GetDirectBufferAddress(env, vec);
+
+                // !DIFFERENCE: ni == vector size -> GrB_ALL .. as no way to get pointer to GrB_ALL object in java
+                GrB_Index* I = NULL;
+                GrB_Index assign_ni = (GrB_Index) ni;
+
+                GrB_Index vectorSize;
+                check_grb_error(GrB_Vector_size(&vectorSize, w));
+
+
+
+                if (vectorSize == assign_ni || is == NULL) {
+                    I = GrB_ALL;
+                }
+                else {
+                    jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                    I = malloc (assign_ni * sizeof (GrB_Index));
+
+                    // just copy :(
+                    for (int i = 0; i < assign_ni; i++) {
+                        I[i] = (GrB_Index)java_is[i];
+                    }
+
+                    (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                }
+
+                // OPTIONAL STUFF
+                GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;
+                GrB_Descriptor d = desc != NULL ? (GrB_Descriptor) (*env)->GetDirectBufferAddress(env, desc) : NULL;
+                GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL;
+
+
+                long res = check_grb_error(GrB_Vector_assign_FP32(w, m, acc, value, I, assign_ni, d));
+
+                if(I != GrB_ALL) {
+                    free(I);
+                }
+
+                return res;
+                }
+
+
+                JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_assignVectorDouble
+                (JNIEnv * env, jclass cls, jobject vec, jobject mask, jobject accum, jdouble value,  jlongArray is, jlong ni, jobject desc) {
+
+                // NON OPTIONAL STUFF
+                GrB_Vector w = (GrB_Vector) (*env)->GetDirectBufferAddress(env, vec);
+
+                // !DIFFERENCE: ni == vector size -> GrB_ALL .. as no way to get pointer to GrB_ALL object in java
+                GrB_Index* I = NULL;
+                GrB_Index assign_ni = (GrB_Index) ni;
+
+                GrB_Index vectorSize;
+                check_grb_error(GrB_Vector_size(&vectorSize, w));
+
+
+
+                if (vectorSize == assign_ni || is == NULL) {
+                    I = GrB_ALL;
+                }
+                else {
+                    jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                    I = malloc (assign_ni * sizeof (GrB_Index));
+
+                    // just copy :(
+                    for (int i = 0; i < assign_ni; i++) {
+                        I[i] = (GrB_Index)java_is[i];
+                    }
+
+                    (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                }
+
+                // OPTIONAL STUFF
+                GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;
+                GrB_Descriptor d = desc != NULL ? (GrB_Descriptor) (*env)->GetDirectBufferAddress(env, desc) : NULL;
+                GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL;
+
+
+                long res = check_grb_error(GrB_Vector_assign_FP64(w, m, acc, value, I, assign_ni, d));
+
+                if(I != GrB_ALL) {
+                    free(I);
+                }
+
+                return res;
+                }
+
+
+
             JNIEXPORT jobject JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_oneUnaryOpBoolean
             (JNIEnv * env, jclass cls) {
             return (*env)->NewDirectByteBuffer(env, GxB_ONE_BOOL, 0);

--- a/graphblas-java/src/main/c/unsafe_ops.c
+++ b/graphblas-java/src/main/c/unsafe_ops.c
@@ -169,15 +169,19 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSMAT_extract
             sizej = grb_nj;
         }
 
-        I = malloc (sizei * sizeof (GrB_Index)) ;
-        J = malloc (sizej * sizeof (GrB_Index)) ;
+        long java_min = -9223372036854775808;
+        I = java_is[0] != java_min ? malloc (sizei * sizeof (GrB_Index)) : GrB_ALL;
+        J = java_js[0] != java_min ? malloc (sizej * sizeof (GrB_Index)) : GrB_ALL;
 
-        for (int i = 0; i < sizei; i++) {
-            I[i] = (GrB_Index)java_is[i];
+        if (I != GrB_ALL) {
+            for (int i = 0; i < sizei; i++) {
+                I[i] = (GrB_Index)java_is[i];
+            }
         }
-
-        for (int i = 0; i < sizej; i++) {
-            J[i] = (GrB_Index)java_js[i];
+        if (J != GrB_ALL) {
+            for (int i = 0; i < sizej; i++) {
+                J[i] = (GrB_Index)java_js[i];
+            }
         }
 
         // Optionals
@@ -241,15 +245,19 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSMAT_assign
             sizej = grb_nj;
         }
 
-        I = malloc (sizei * sizeof (GrB_Index)) ;
-        J = malloc (sizej * sizeof (GrB_Index)) ;
+        long java_min = -9223372036854775808;
+        I = java_is[0] != java_min ? malloc (sizei * sizeof (GrB_Index)) : GrB_ALL;
+        J = java_js[0] != java_min ? malloc (sizej * sizeof (GrB_Index)) : GrB_ALL;
 
-        for (int i = 0; i < sizei; i++) {
-            I[i] = (GrB_Index)java_is[i];
+        if (I != GrB_ALL) {
+            for (int i = 0; i < sizei; i++) {
+                I[i] = (GrB_Index)java_is[i];
+            }
         }
-
-        for (int i = 0; i < sizej; i++) {
-            J[i] = (GrB_Index)java_js[i];
+        if (J != GrB_ALL) {
+            for (int i = 0; i < sizej; i++) {
+                J[i] = (GrB_Index)java_js[i];
+            }
         }
 
         // Optionals
@@ -313,15 +321,19 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSMAT_subAssign
             sizej = grb_nj;
         }
 
-        I = malloc (sizei * sizeof (GrB_Index)) ;
-        J = malloc (sizej * sizeof (GrB_Index)) ;
+        long java_min = -9223372036854775808;
+        I = java_is[0] != java_min ? malloc (sizei * sizeof (GrB_Index)) : GrB_ALL;
+        J = java_js[0] != java_min ? malloc (sizej * sizeof (GrB_Index)) : GrB_ALL;
 
-        for (int i = 0; i < sizei; i++) {
-            I[i] = (GrB_Index)java_is[i];
+        if (I != GrB_ALL) {
+            for (int i = 0; i < sizei; i++) {
+                I[i] = (GrB_Index)java_is[i];
+            }
         }
-
-        for (int i = 0; i < sizej; i++) {
-            J[i] = (GrB_Index)java_js[i];
+        if (J != GrB_ALL) {
+            for (int i = 0; i < sizej; i++) {
+                J[i] = (GrB_Index)java_js[i];
+            }
         }
 
         // Optionals

--- a/graphblas-java/src/main/c/unsafe_ops.c
+++ b/graphblas-java/src/main/c/unsafe_ops.c
@@ -193,8 +193,12 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSMAT_extract
 
         (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
         (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-        free(I);
-        free(J);
+        if (I != GrB_ALL) {
+            free(I);
+        }
+        if (J != GrB_ALL) {
+            free(J);
+        }
 
        return res;
 
@@ -269,8 +273,12 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSMAT_assign
 
         (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
         (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-        free(I);
-        free(J);
+        if (I != GrB_ALL) {
+            free(I);
+        }
+        if (J != GrB_ALL) {
+            free(J);
+        }
 
        return res;
 
@@ -345,8 +353,12 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSMAT_subAssign
 
         (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
         (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-        free(I);
-        free(J);
+        if (I != GrB_ALL) {
+            free(I);
+        }
+        if (J != GrB_ALL) {
+            free(J);
+        }
 
        return res;
 

--- a/graphblas-java/src/main/java/com/github/fabianmurariu/unsafe/GRAPHBLAS.java
+++ b/graphblas-java/src/main/java/com/github/fabianmurariu/unsafe/GRAPHBLAS.java
@@ -89,6 +89,14 @@ public final class GRAPHBLAS {
     public static native long buildVectorFromTuplesDouble(Buffer mat, long[] is, double[] vs, long nvals, Buffer dupOp);
     public static native long extractVectorTuplesDouble(Buffer mat, double[] vs, long[] is);
 
+   public static native long assignVectorBoolean(Buffer vec, Buffer mask, Buffer accum, boolean value, long[] I, long ni, Buffer desc);
+   public static native long assignVectorByte(Buffer vec, Buffer mask, Buffer accum, byte value, long[] I, long ni, Buffer desc);
+   public static native long assignVectorShort(Buffer vec, Buffer mask, Buffer accum, short value, long[] I, long ni, Buffer desc);
+   public static native long assignVectorInt(Buffer vec, Buffer mask, Buffer accum, int value, long[] I, long ni, Buffer desc);
+   public static native long assignVectorLong(Buffer vec, Buffer mask, Buffer accum, long value, long[] I, long ni, Buffer desc);
+   public static native long assignVectorFloat(Buffer vec, Buffer mask, Buffer accum, float value, long[] I, long ni, Buffer desc);
+   public static native long assignVectorDouble(Buffer vec, Buffer mask, Buffer accum, double value, long[] I, long ni, Buffer desc);
+
     public static native Buffer oneUnaryOpBoolean();
     public static native Buffer identityUnaryOpBoolean();
     public static native Buffer addInvUnaryOpBoolean();

--- a/graphblas-java/src/main/java/com/github/fabianmurariu/unsafe/GRBCORE.java
+++ b/graphblas-java/src/main/java/com/github/fabianmurariu/unsafe/GRBCORE.java
@@ -65,6 +65,7 @@ public final class GRBCORE {
     public static long GxB_RANGE = Long.MAX_VALUE;
     public static long GxB_STRIDE = Long.MAX_VALUE -1;
     public static long GxB_BACKWARDS = Long.MAX_VALUE -2;
+    public static long NOT_REALLY_GRB_ALL = Long.MIN_VALUE; // placeholder for GrB_ALL
     public static native long initNonBlocking();
     public static native long grbWait();
     public static native long grbFinalize();

--- a/graphblas-java/src/main/java/com/github/fabianmurariu/unsafe/GRBCORE.java
+++ b/graphblas-java/src/main/java/com/github/fabianmurariu/unsafe/GRBCORE.java
@@ -66,6 +66,7 @@ public final class GRBCORE {
     public static long GxB_STRIDE = Long.MAX_VALUE -1;
     public static long GxB_BACKWARDS = Long.MAX_VALUE -2;
     public static long NOT_REALLY_GRB_ALL = Long.MIN_VALUE; // placeholder for GrB_ALL
+    public static long[] GrB_ALL = {NOT_REALLY_GRB_ALL};
     public static native long initNonBlocking();
     public static native long grbWait();
     public static native long grbFinalize();

--- a/graphblas-java/src/main/java/com/github/fabianmurariu/unsafe/GRBOPSMAT.java
+++ b/graphblas-java/src/main/java/com/github/fabianmurariu/unsafe/GRBOPSMAT.java
@@ -9,7 +9,7 @@ public class GRBOPSMAT {
     }
 
     /**
-     * C<Mask> = accum (C, A*B)
+     * {@code C<Mask> = accum (C, A*B)}
      *
      * @param C input/output matrix for results
      * @param mask optional mask for C, unused if NULL
@@ -18,13 +18,12 @@ public class GRBOPSMAT {
      * @param A first input: matrix A
      * @param B second input: matrix B
      * @param desc descriptor for C, Mask, A, and B
-     * @return
-     *  GrB_Info status
+     * @return GrB_Info status
      */
     public static native int mxm(Buffer C, Buffer mask, Buffer accum, Buffer semiring, Buffer A, Buffer B, Buffer desc);
 
     /**
-     * C<Mask> = accum (C, u'*A)
+     * {@code C<Mask> = accum (C, u'*A)}
      *
      * @param w input/output vector for results
      * @param mask optional mask for C, unused if NULL
@@ -33,13 +32,12 @@ public class GRBOPSMAT {
      * @param u first input: vector u
      * @param A second input: matrix A
      * @param desc descriptor for C, Mask, A, and B
-     * @return
-     *  GrB_Info status
+     * @return GrB_Info status
      */
     public static native int vxm(Buffer w, Buffer mask, Buffer accum, Buffer semiring, Buffer u, Buffer A, Buffer desc);
 
     /**
-     * C<Mask> = accum (C, A*u)
+     * {@code C<Mask> = accum (C, A*u)}
      *
      * @param w input/output vector for results
      * @param mask optional mask for C, unused if NULL
@@ -48,13 +46,12 @@ public class GRBOPSMAT {
      * @param A first input: matrix A
      * @param u second input: vector u
      * @param desc descriptor for C, Mask, A, and B
-     * @return
-     *  GrB_Info status
+     * @return GrB_Info status
      */
     public static native int mxv(Buffer w, Buffer mask, Buffer accum, Buffer semiring, Buffer A, Buffer u, Buffer desc);
 
     /**
-     * C<Mask> = accum (C, A.*B)
+     * {@code C<Mask> = accum (C, A.*B)}
      *
      * @param C input/output matrix for results
      * @param mask optional mask for C, unused if NULL
@@ -63,13 +60,12 @@ public class GRBOPSMAT {
      * @param A first input: matrix A
      * @param B second input: matrix B
      * @param desc descriptor for C, Mask, A, and B
-     * @return
-     *  GrB_Info status
+     * @return GrB_Info status
      */
     public static native int elemWiseMulIntersectMonoid(Buffer C, Buffer mask, Buffer accum, Buffer monoid, Buffer A, Buffer B, Buffer desc);
 
     /**
-     * C<Mask> = accum (C, A.*B)
+     * {@code C<Mask> = accum (C, A.*B)}
      *
      * @param C input/output matrix for results
      * @param mask optional mask for C, unused if NULL
@@ -78,13 +74,12 @@ public class GRBOPSMAT {
      * @param A first input: matrix A
      * @param B second input: matrix B
      * @param desc descriptor for C, Mask, A, and B
-     * @return
-     *  GrB_Info status
+     * @return GrB_Info status
      */
     public static native int elemWiseMulIntersectBinOp(Buffer C, Buffer mask, Buffer accum, Buffer binOp, Buffer A, Buffer B, Buffer desc);
 
     /**
-     * C<Mask> = accum (C, A.+B)
+     * {@code C<Mask> = accum (C, A.+B)}
      *
      * @param C input/output matrix for results
      * @param mask optional mask for C, unused if NULL
@@ -93,13 +88,12 @@ public class GRBOPSMAT {
      * @param A first input: matrix A
      * @param B second input: matrix B
      * @param desc descriptor for C, Mask, A, and B
-     * @return
-     *  GrB_Info status
+     * @return GrB_Info status
      */
     public static native int elemWiseAddUnionMonoid(Buffer C, Buffer mask, Buffer accum, Buffer monoid, Buffer A, Buffer B, Buffer desc);
 
     /**
-     * C<Mask> = accum (C, A.+B)
+     * {@code C<Mask> = accum (C, A.+B)}
      *
      * @param C input/output matrix for results
      * @param mask optional mask for C, unused if NULL
@@ -108,13 +102,12 @@ public class GRBOPSMAT {
      * @param A first input: matrix A
      * @param B second input: matrix B
      * @param desc descriptor for C, Mask, A, and B
-     * @return
-     *  GrB_Info status
+     * @return GrB_Info status
      */
     public static native int elemWiseAddUnionBinOp(Buffer C, Buffer mask, Buffer accum, Buffer binOp, Buffer A, Buffer B, Buffer desc);
 
     /**
-     * C<Mask>(I,J) = accum (C(I,J),A)
+     * {@code C<Mask>(I,J) = accum (C(I,J),A)}
      *
      * @param C input/output matrix for results
      * @param mask optional mask for C, unused if NULL
@@ -125,12 +118,12 @@ public class GRBOPSMAT {
      * @param J column indices
      * @param nj number of column indices
      * @param desc descriptor for C, Mask, and A
-     * @return
+     * @return GrB_Info status
      */
     public static native long assign(Buffer C, Buffer mask, Buffer accum, Buffer A, long[] I, long ni, long[] J, long nj, Buffer desc);
 
     /**
-     * C(I,J)<Mask> = accum (C(I,J),A)
+     * {@code C(I,J)<Mask> = accum (C(I,J),A)}
      *
      * @param C input/output matrix for results
      * @param mask optional mask for C, unused if NULL
@@ -141,12 +134,12 @@ public class GRBOPSMAT {
      * @param J column indices
      * @param nj number of column indices
      * @param desc descriptor for C, Mask, and A
-     * @return
+     * @return GrB_Info status
      */
     public static native long subAssign(Buffer C, Buffer mask, Buffer accum, Buffer A, long[] I, long ni, long[] J, long nj, Buffer desc);
 
     /**
-     * C<Mask> = accum (C, A(I,J))
+     * {@code C<Mask> = accum (C, A(I,J))}
      *
      * @param C input/output matrix for results
      * @param mask optional mask for C, unused if NULL
@@ -157,7 +150,7 @@ public class GRBOPSMAT {
      * @param J column indices
      * @param nj number of column indices
      * @param desc descriptor for C, Mask, and A
-     * @return
+     * @return GrB_Info status
      */
     public static native long extract(Buffer C, Buffer mask, Buffer accum, Buffer A, long[] I, long ni, long[] J, long nj, Buffer desc);
 

--- a/graphblas-java/src/main/java/com/github/fabianmurariu/unsafe/GrBJNIException.java
+++ b/graphblas-java/src/main/java/com/github/fabianmurariu/unsafe/GrBJNIException.java
@@ -1,0 +1,8 @@
+package com.github.fabianmurariu.unsafe;
+
+public class GrBJNIException extends RuntimeException{
+    public final long code;
+    public GrBJNIException(long code) {
+        this.code = code;
+    }
+}

--- a/graphblas-java/src/main/templates/c/unsafe_gen.c.ftl
+++ b/graphblas-java/src/main/templates/c/unsafe_gen.c.ftl
@@ -206,26 +206,20 @@ long check_grb_error(GrB_Info info);
 
                 // !DIFFERENCE: ni == vector size -> GrB_ALL .. as no way to get pointer to GrB_ALL object in java
                 GrB_Index* I = NULL;
-                GrB_Index assign_ni = (GrB_Index) ni;
+                GrB_Index grb_ni = (GrB_Index) ni;
+                jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                long java_min = -9223372036854775808;
 
-                GrB_Index vectorSize;
-                check_grb_error(GrB_Vector_size(&vectorSize, w));
-
-
-
-                if (vectorSize == assign_ni || is == NULL) {
+                if (java_is[0] == java_min) {
                     I = GrB_ALL;
                 }
                 else {
-                    jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                    I = malloc (assign_ni * sizeof (GrB_Index));
+                    I = malloc (grb_ni * sizeof (GrB_Index));
 
                     // just copy :(
-                    for (int i = 0; i < assign_ni; i++) {
+                    for (int i = 0; i < grb_ni; i++) {
                         I[i] = (GrB_Index)java_is[i];
                     }
-
-                    (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 }
 
                 // OPTIONAL STUFF
@@ -234,8 +228,9 @@ long check_grb_error(GrB_Info info);
                 GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL;
 
 
-                long res = check_grb_error(GrB_Vector_assign_${prop.grb_type}(w, m, acc, value, I, assign_ni, d));
+                long res = check_grb_error(GrB_Vector_assign_${prop.grb_type}(w, m, acc, value, I, grb_ni, d));
 
+                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 if(I != GrB_ALL) {
                     free(I);
                 }

--- a/graphblas-java/src/main/templates/java/com/github/fabianmurariu/unsafe/GRAPHBLAS.java.ftl
+++ b/graphblas-java/src/main/templates/java/com/github/fabianmurariu/unsafe/GRAPHBLAS.java.ftl
@@ -30,6 +30,10 @@ public final class GRAPHBLAS {
 </#list>
 
 <#list properties.types as prop>
+   public static native long assignVector${prop.java_type?cap_first}(Buffer vec, Buffer mask, Buffer accum, ${prop.java_type} value, long[] I, long ni, Buffer desc);
+</#list>
+
+<#list properties.types as prop>
     <#list properties.unary_ops as uop>
     public static native Buffer ${uop.name}UnaryOp${prop.java_type?cap_first}();
     </#list>

--- a/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/AssignExtractSpec.scala
+++ b/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/AssignExtractSpec.scala
@@ -47,6 +47,17 @@ trait AssignExtractSpec {
 
       SparseMatrixHandler[T].extractTuples(into) should contain theSameElementsAs expected
     }
+
+    it should s"call GrB_extract all for GrB_Matrix of type ${CT.toString()}" in forAll { mt: MatrixTuples[T] =>
+      val mat = SparseMatrixHandler[T].buildMatrix(mt)
+
+      val into = SparseMatrixHandler[T].createMatrix(mt.dim.rows, mt.dim.cols)
+
+      val res = GRBOPSMAT.extract(into, null, null, mat, GRBCORE.GrB_ALL, mt.dim.rows, GRBCORE.GrB_ALL, mt.dim.cols, null)
+      assert(res == 0)
+
+      SparseMatrixHandler[T].extractTuples(into) should contain theSameElementsAs SparseMatrixHandler[T].extractTuples(mat)
+    }
   }
 
   private def testGrBAssign[T: SparseMatrixHandler](implicit A: Arbitrary[MatrixTuples[T]], CT: ClassTag[T]): Unit = {

--- a/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/AssignScalarSpec.scala
+++ b/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/AssignScalarSpec.scala
@@ -29,15 +29,7 @@ trait AssignScalarSpec {
 
       val v = mt.vals.head._2
 
-      v match {
-        case b: Boolean => GRAPHBLAS.assignVectorBoolean(vec, null, null, b, null, size, null)
-        case b: Byte => GRAPHBLAS.assignVectorByte(vec, null, null, b, null, size, null)
-        case b: Short => GRAPHBLAS.assignVectorShort(vec, null, null, b, null, size, null)
-        case b: Int => GRAPHBLAS.assignVectorInt(vec, null, null, b, null, size, null)
-        case b: Long => GRAPHBLAS.assignVectorLong(vec, null, null, b, null, size, null)
-        case b: Float => GRAPHBLAS.assignVectorFloat(vec, null, null, b, null, size, null)
-        case b: Double => GRAPHBLAS.assignVectorDouble(vec, null, null, b, null, size, null)
-      }
+      SparseVectorHandler[T].assign(vec)(v)
 
       GRBCORE.nvalsVector(vec) shouldBe size
 

--- a/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/AssignScalarSpec.scala
+++ b/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/AssignScalarSpec.scala
@@ -1,0 +1,51 @@
+package com.github.fabianmurariu.unsafe
+
+import org.scalacheck.Arbitrary
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+import scala.reflect.ClassTag
+
+trait AssignScalarSpec {
+  self: AnyFlatSpec with ScalaCheckDrivenPropertyChecks with Matchers =>
+
+  behavior of "GrB_Vector_assign"
+
+  testVectorAssignScalar[Boolean]
+  testVectorAssignScalar[Byte]
+  testVectorAssignScalar[Short]
+  testVectorAssignScalar[Int]
+  testVectorAssignScalar[Long]
+  testVectorAssignScalar[Float]
+  testVectorAssignScalar[Double]
+
+  def testVectorAssignScalar[T: SparseVectorHandler](implicit A: Arbitrary[VectorVals[T]], CT: ClassTag[T]) = {
+    it should s"create a vector of type ${CT.toString()}, assign a scalar value" in forAll { mt: VectorVals[T] =>
+      val handler = SparseVectorHandler[T]
+
+      val size = 10
+      val vec = handler.createVector(size)
+
+      val v = mt.vals.head._2
+
+      v match {
+        case b: Boolean => GRAPHBLAS.assignVectorBoolean(vec, null, null, b, null, size, null)
+        case b: Byte => GRAPHBLAS.assignVectorByte(vec, null, null, b, null, size, null)
+        case b: Short => GRAPHBLAS.assignVectorShort(vec, null, null, b, null, size, null)
+        case b: Int => GRAPHBLAS.assignVectorInt(vec, null, null, b, null, size, null)
+        case b: Long => GRAPHBLAS.assignVectorLong(vec, null, null, b, null, size, null)
+        case b: Float => GRAPHBLAS.assignVectorFloat(vec, null, null, b, null, size, null)
+        case b: Double => GRAPHBLAS.assignVectorDouble(vec, null, null, b, null, size, null)
+      }
+
+      GRBCORE.nvalsVector(vec) shouldBe size
+
+      for (i <- 0 to size) {
+        handler.get(vec)(i).headOption shouldBe Some(v)
+      }
+
+      GRBCORE.freeVector(vec)
+    }
+  }
+}

--- a/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/GRAPHBLASSpec.scala
+++ b/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/GRAPHBLASSpec.scala
@@ -15,6 +15,7 @@ class GRAPHBLASSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks with
   with DescriptorSpec
   with MxmSpec
   with AssignExtractSpec
+  with AssignScalarSpec
   with ElemWiseSpec {
 
   behavior of "GrB_Matrix"

--- a/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/RemoveSpec.scala
+++ b/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/RemoveSpec.scala
@@ -31,6 +31,35 @@ trait RemoveSpec {
   testRemoveElementFromVector[Float]
   testRemoveElementFromVector[Double]
 
+  behavior of "GrB_Vector_clear"
+
+  it should s"create a vector, check elements exist, clear the vector then verify they are gone" in forAll { mt: VectorVals[Int] =>
+    val handler = SparseVectorHandler[Int]
+
+    val vec = handler.buildVector(mt)
+
+    GRBCORE.nvalsVector(vec) shouldBe mt.vals.size
+
+    handler.clear(vec)
+
+    GRBCORE.nvalsVector(vec) shouldBe 0
+  }
+
+  behavior of "GrB_Matrix_clear"
+
+  it should s"create a matrix, check elements exist, clear the matrix then verify they are gone" in forAll { mt: MatrixTuples[Int] =>
+    val handler = SparseMatrixHandler[Int]
+
+    val mat = handler.buildMatrix(mt)
+
+    GRBCORE.nvalsMatrix(mat) shouldBe mt.vals.size
+
+    handler.clear(mat)
+
+    GRBCORE.nvalsMatrix(mat) shouldBe 0
+  }
+
+
   def testRemoveElementFromMatrix[T: SparseMatrixHandler](implicit A: Arbitrary[MatrixTuples[T]], CT: ClassTag[T]) = {
     it should s"create a matrix of type ${CT.toString()}, check elements exist, remove them then verify they are gone" in forAll { mt: MatrixTuples[T] =>
       val handler = SparseMatrixHandler[T]

--- a/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/SparseMatrixHandler.scala
+++ b/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/SparseMatrixHandler.scala
@@ -22,6 +22,9 @@ trait SparseMatrixHandler[T] {
   def remove(mat: Buffer)(i: Long, j: Long): Unit =
     GRBCORE.removeElementMatrix(mat, i, j)
 
+  def clear(mat: Buffer): Unit =
+    GRBCORE.clearMatrix(mat)
+
   def extractTuples(mat: Buffer): Array[T]
 
   def extractAllTuples(mat: Buffer): Seq[(Long, Long, T)] = Seq.empty

--- a/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/SparseVectorHandler.scala
+++ b/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/SparseVectorHandler.scala
@@ -22,6 +22,9 @@ trait SparseVectorHandler[T] {
   def remove(vec: Buffer)(i: Long): Unit =
     GRBCORE.removeElementVector(vec, i)
 
+  def clear(vec: Buffer): Unit =
+    GRBCORE.clearVec(vec)
+
 }
 
 object SparseVectorHandler {

--- a/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/SparseVectorHandler.scala
+++ b/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/SparseVectorHandler.scala
@@ -19,6 +19,11 @@ trait SparseVectorHandler[T] {
 
   def set(vec: Buffer)(i: Long, v: T): Unit
 
+  def assign(vec: Buffer)(v: T): Unit
+  
+  def size(vec: Buffer) : Long = 
+    GRBCORE.size(vec)
+
   def remove(vec: Buffer)(i: Long): Unit =
     GRBCORE.removeElementVector(vec, i)
 
@@ -36,6 +41,9 @@ object SparseVectorHandler {
     def get(vec: Buffer)(i: Long): Array[Boolean] = GRAPHBLAS.getVectorElementBoolean(vec, i)
 
     def set(vec: Buffer)(i: Long, t: Boolean): Unit = GRAPHBLAS.setVectorElementBoolean(vec, i, t)
+
+    def assign(vec: Buffer)(v: Boolean): Unit = 
+      GRAPHBLAS.assignVectorBoolean(vec, null, null, v, GRBCORE.GrB_ALL, size(vec), null)
   }
 
   implicit val byteVectorHandler: SparseVectorHandler[Byte] = new SparseVectorHandler[Byte] {
@@ -44,6 +52,9 @@ object SparseVectorHandler {
     def get(vec: Buffer)(i: Long): Array[Byte] = GRAPHBLAS.getVectorElementByte(vec, i)
 
     def set(vec: Buffer)(i: Long, t: Byte): Unit = GRAPHBLAS.setVectorElementByte(vec, i, t)
+
+    def assign(vec: Buffer)(v: Byte): Unit =
+      GRAPHBLAS.assignVectorByte(vec, null, null, v, GRBCORE.GrB_ALL, size(vec), null)
   }
 
   implicit val shortVectorHandler: SparseVectorHandler[Short] = new SparseVectorHandler[Short] {
@@ -52,6 +63,9 @@ object SparseVectorHandler {
     def get(vec: Buffer)(i: Long): Array[Short] = GRAPHBLAS.getVectorElementShort(vec, i)
 
     def set(vec: Buffer)(i: Long, t: Short): Unit = GRAPHBLAS.setVectorElementShort(vec, i, t)
+
+    def assign(vec: Buffer)(v: Short): Unit =
+      GRAPHBLAS.assignVectorShort(vec, null, null, v, GRBCORE.GrB_ALL, size(vec), null)
   }
 
   implicit val intVectorHandler: SparseVectorHandler[Int] = new SparseVectorHandler[Int] {
@@ -60,6 +74,9 @@ object SparseVectorHandler {
     def get(vec: Buffer)(i: Long): Array[Int] = GRAPHBLAS.getVectorElementInt(vec, i)
 
     def set(vec: Buffer)(i: Long, t: Int): Unit = GRAPHBLAS.setVectorElementInt(vec, i, t)
+
+    def assign(vec: Buffer)(v: Int): Unit =
+      GRAPHBLAS.assignVectorInt(vec, null, null, v, GRBCORE.GrB_ALL, size(vec), null)
   }
 
   implicit val longVectorHandler: SparseVectorHandler[Long] = new SparseVectorHandler[Long] {
@@ -68,6 +85,9 @@ object SparseVectorHandler {
     def get(vec: Buffer)(i: Long): Array[Long] = GRAPHBLAS.getVectorElementLong(vec, i)
 
     def set(vec: Buffer)(i: Long, t: Long): Unit = GRAPHBLAS.setVectorElementLong(vec, i, t)
+
+    def assign(vec: Buffer)(v: Long): Unit =
+      GRAPHBLAS.assignVectorLong(vec, null, null, v, GRBCORE.GrB_ALL, size(vec), null)
   }
 
   implicit val floatVectorHandler: SparseVectorHandler[Float] = new SparseVectorHandler[Float] {
@@ -76,6 +96,9 @@ object SparseVectorHandler {
     def get(vec: Buffer)(i: Long): Array[Float] = GRAPHBLAS.getVectorElementFloat(vec, i)
 
     def set(vec: Buffer)(i: Long, t: Float): Unit = GRAPHBLAS.setVectorElementFloat(vec, i, t)
+
+    def assign(vec: Buffer)(v: Float): Unit =
+      GRAPHBLAS.assignVectorFloat(vec, null, null, v, GRBCORE.GrB_ALL, size(vec), null)
   }
 
   implicit val doubleVectorHandler: SparseVectorHandler[Double] = new SparseVectorHandler[Double] {
@@ -84,5 +107,8 @@ object SparseVectorHandler {
     def get(vec: Buffer)(i: Long): Array[Double] = GRAPHBLAS.getVectorElementDouble(vec, i)
 
     def set(vec: Buffer)(i: Long, t: Double): Unit = GRAPHBLAS.setVectorElementDouble(vec, i, t)
+
+    def assign(vec: Buffer)(v: Double): Unit =
+      GRAPHBLAS.assignVectorDouble(vec, null, null, v, GRBCORE.GrB_ALL, size(vec), null)
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.fabianmurariu</groupId>
     <artifactId>graphblas-java-native</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -127,13 +127,12 @@
               <goal>jar</goal>
             </goals>
             <configuration>
-              <!-- switch on dependency-driven aggregation -->
-		    <includeDependencySources>true</includeDependencySources>                                         <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
-                            <skip>true</skip>
- 
-              <dependencySourceExcludes>
-                <!-- exclude ONLY commons-cli artifacts -->
-                <dependencySourceExclude>commons-cli:*</dependencySourceExclude>
+                <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
+                <detectJavaApiLink>false</detectJavaApiLink>
+                <source>8</source>
+   		    <includeDependencySources>true</includeDependencySources>
+                <dependencySourceExcludes>
+                    <dependencySourceExclude>commons-cli:*</dependencySourceExclude>
               </dependencySourceExcludes>
             </configuration>
           </execution>


### PR DESCRIPTION
For `clear` the java method already existed, but was not implemented in C yet.
`assignVector{type}` was a bit more tricky, as the option `GBR_ALL` is a specific address, which we cannot use in Java.
Instead I check if the number of entries to write equals the size of the vector .. e.g. assigning every value (`ni == Grb_size(vec)`).

This is based on the PR #4. 
It PR addresses the issue #5.
 