### PR TITLE
Map global options

### DIFF
--- a/graphblas-java/src/main/c/unsafe.c
+++ b/graphblas-java/src/main/c/unsafe.c
@@ -26,6 +26,11 @@ JNIEXPORT jint JNICALL JNI_OnLoad (JavaVM *jvm, void *reserved) {
             return check_grb_error(GrB_init(GrB_NONBLOCKING) );
             }
 
+            JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_initBlocking
+            (JNIEnv * env, jclass cls) {
+            return check_grb_error(GrB_init(GrB_BLOCKING) );
+            }
+
             JNIEXPORT jint JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_getGlobalInt
             (JNIEnv * env, jclass cls, jint field) {
             GxB_Option_Field global_field = (GxB_Option_Field) field;

--- a/graphblas-java/src/main/c/unsafe.c
+++ b/graphblas-java/src/main/c/unsafe.c
@@ -26,6 +26,36 @@ JNIEXPORT jint JNICALL JNI_OnLoad (JavaVM *jvm, void *reserved) {
             return check_grb_error(GrB_init(GrB_NONBLOCKING) );
             }
 
+            JNIEXPORT jint JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_getGlobalInt
+            (JNIEnv * env, jclass cls, jint field) {
+            GxB_Option_Field global_field = (GxB_Option_Field) field;
+            int value;
+            check_grb_error(GxB_Global_Option_get(global_field, &value));
+
+            return (jint) value;
+            }
+
+            JNIEXPORT jdouble JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_getGlobalDouble
+            (JNIEnv * env, jclass cls, jint field) {
+            GxB_Option_Field global_field = (GxB_Option_Field) field;
+            double value;
+            check_grb_error(GxB_Global_Option_get(global_field, &value));
+
+            return (jdouble) value;
+            }
+
+            JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_setGlobalInt
+            (JNIEnv * env, jclass cls, jint field, jint value) {
+            GxB_Option_Field global_field = (GxB_Option_Field) field;
+            return check_grb_error(GxB_Global_Option_set(global_field, value));
+            }
+
+            JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_setGlobalDouble
+            (JNIEnv * env, jclass cls, jint field, jdouble value) {
+            GxB_Option_Field global_field = (GxB_Option_Field) field;
+            return check_grb_error(GxB_Global_Option_set(global_field, value));
+            }
+
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_grbWait
             (JNIEnv * env, jclass cls) {
             return check_grb_error(GrB_wait());

--- a/graphblas-java/src/main/java/com/github/fabianmurariu/unsafe/GRBCORE.java
+++ b/graphblas-java/src/main/java/com/github/fabianmurariu/unsafe/GRBCORE.java
@@ -68,6 +68,7 @@ public final class GRBCORE {
     public static long NOT_REALLY_GRB_ALL = Long.MIN_VALUE; // placeholder for GrB_ALL
     public static long[] GrB_ALL = {NOT_REALLY_GRB_ALL};
     public static native long initNonBlocking();
+    public static native long initBlocking();
     public static native long grbWait();
     public static native long grbFinalize();
 
@@ -141,6 +142,10 @@ public final class GRBCORE {
     public static int GxB_BY_ROW = 0; // CSR
     public static int GxB_BY_COL = 1; // CSC
     public static int GxB_NO_FORMAT = -1; // not defined
+
+    // for GrB_Mode
+    public static int GrB_NONBLOCKING = 0;
+    public static int GrB_BLOCKING = 1;
 
     public static int GxB_THREAD_NONE = 0;    // no threading
     public static int GxB_THREAD_OPENMP = 1;  // OpenMP

--- a/graphblas-java/src/main/java/com/github/fabianmurariu/unsafe/GRBCORE.java
+++ b/graphblas-java/src/main/java/com/github/fabianmurariu/unsafe/GRBCORE.java
@@ -112,6 +112,50 @@ public final class GRBCORE {
     // Monoid
     public static native long freeMonoid(Buffer monoid);
 
+    // Global options
+    // Fields (get and set)
+    public static int GxB_HYPER = 0;
+    public static int GxB_FORMAT = 1;  // defines CSR/CSC format: GxB_BY_ROW or GxB_BY_COL
+    public static int GxB_NTHREADS = 5;
+    public static int GxB_CHUNK = 7;
+
+    // Fields only for get (only supporting the ones returning ints for now)
+    public static int GxB_MODE = 2;  // mode passed to GrB_init (blocking or non-blocking)
+    public static int GxB_THREAD_SAFETY = 3; // thread library that allows GraphBLAS to be thread-safe for user threads.
+    public static int GxB_THREADING = 4;  // thread library used for internal GraphBLAS threads
+    //public static int GxB_LIBRARY_NAME = 8;             // name of the library (char *)
+    //public static int GxB_LIBRARY_VERSION = 9;        // library version (3 int's)
+    //public static int GxB_LIBRARY_DATE = 10;          // date of the library (char *)
+    //public static int GxB_LIBRARY_ABOUT = 11;         // about the library (char *)
+    //public static int GxB_LIBRARY_URL = 12;           // URL for the library (char *)
+    //public static int GxB_LIBRARY_LICENSE = 13;       // license of the library (char *)
+    //public static int GxB_LIBRARY_COMPILE_DATE = 14;  // date library was compiled (char *)
+    //public static int GxB_LIBRARY_COMPILE_TIME = 15;  // time library was compiled (char *)
+    //public static int GxB_API_VERSION = 16;           // API version (3 int's)
+    //public static int GxB_API_DATE = 17;              // date of the API (char *)
+    //public static int GxB_API_ABOUT = 18;             // about the API (char *)
+    //public static int GxB_API_URL = 19;               // URL for the API (char *)
+
+    // Values
+    // for GxB_FORMAT
+    public static int GxB_BY_ROW = 0; // CSR
+    public static int GxB_BY_COL = 1; // CSC
+    public static int GxB_NO_FORMAT = -1; // not defined
+
+    public static int GxB_THREAD_NONE = 0;    // no threading
+    public static int GxB_THREAD_OPENMP = 1;  // OpenMP
+    public static int GxB_THREAD_POSIX = 2;  // POSIX pthreads
+    public static int GxB_THREAD_WINDOWS = 3; // Windows threads
+    public static int GxB_THREAD_ANSI = 4;     // ANSI C11 threads
+
+
+    public static native long setGlobalInt(int field, int value);
+    // f.i. for hyper ratio or chunk
+    public static native long setGlobalDouble(int field, double value);
+    public static native int getGlobalInt(int field);
+    public static native double getGlobalDouble(int field);
+    // TODO return global string value or int array? f.i. version or library date
+
     // Descriptor
     // Fields
     public static int GrB_OUTP = 0;   // descriptor for output of a method

--- a/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/GRAPHBLASSpec.scala
+++ b/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/GRAPHBLASSpec.scala
@@ -108,6 +108,8 @@ class GRAPHBLASSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks with
     val hyperRatio = 0.001337
     GRBCORE.setGlobalDouble(GRBCORE.GxB_HYPER, hyperRatio)
     GRBCORE.getGlobalDouble(GRBCORE.GxB_HYPER) shouldBe hyperRatio
+
+    GRBCORE.getGlobalInt(GRBCORE.GxB_MODE) shouldBe GRBCORE.GrB_NONBLOCKING
   }
 
   override protected def beforeAll(): Unit = {

--- a/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/GRAPHBLASSpec.scala
+++ b/graphblas-java/src/test/scala/com/github/fabianmurariu/unsafe/GRAPHBLASSpec.scala
@@ -98,6 +98,18 @@ class GRAPHBLASSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks with
 
   testSettersAndGettersVector[Double](GRAPHBLAS.doubleType()) { (vec, i, value) => GRAPHBLAS.setVectorElementDouble(vec, i, value) } { (vec, i) => GRAPHBLAS.getVectorElementDouble(vec, i).headOption }
 
+  behavior of "GxB_Global_Option_get/set"
+
+  it should "get/set concurrency and hyper-ratio" in {
+    val concurrency = 7
+    GRBCORE.setGlobalInt(GRBCORE.GxB_NTHREADS, concurrency)
+    GRBCORE.getGlobalInt(GRBCORE.GxB_NTHREADS) shouldBe concurrency
+
+    val hyperRatio = 0.001337
+    GRBCORE.setGlobalDouble(GRBCORE.GxB_HYPER, hyperRatio)
+    GRBCORE.getGlobalDouble(GRBCORE.GxB_HYPER) shouldBe hyperRatio
+  }
+
   override protected def beforeAll(): Unit = {
     GRBCORE.initNonBlocking()
   }


### PR DESCRIPTION
for #6.

The problem I had, was that the user needs to know, which type the global field has.
For now I only added support for numerical fields.

Reasoning for adding `initBlocking()`:
`initBlocking()` should only be used for debugging according to the User-Guide, however my pure java implementation (https://github.com/FlorentinD/ejml/pull/5) has no non-blocking mode, so I want to use this mode for a better comparison.