### PR TITLE
Avoid copying java arrays

### DIFF
--- a/graphblas-java/src/main/c/unsafe.c
+++ b/graphblas-java/src/main/c/unsafe.c
@@ -282,7 +282,7 @@ JNIEXPORT jint JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_getFormat
 JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBCORE_neverHyper
   (JNIEnv * env, jclass cls, jobject mat) {
         GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
-        check_grb_error(GxB_Matrix_Option_set(A, GxB_FORMAT, GxB_NEVER_HYPER));
+        return check_grb_error(GxB_Matrix_Option_set(A, GxB_FORMAT, GxB_NEVER_HYPER));
   }
 
 

--- a/graphblas-java/src/main/c/unsafe_gen.c
+++ b/graphblas-java/src/main/c/unsafe_gen.c
@@ -981,12 +981,7 @@ long check_grb_error(GrB_Info info);
                 jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 long java_min = -9223372036854775808;
 
-                if (java_is[0] == java_min) {
-                    I = GrB_ALL;
-                }
-                else {
-                    I = (GrB_Index*) java_is;
-                }
+                I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
                 // OPTIONAL STUFF
                 GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;
@@ -1013,12 +1008,7 @@ long check_grb_error(GrB_Info info);
                 jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 long java_min = -9223372036854775808;
 
-                if (java_is[0] == java_min) {
-                    I = GrB_ALL;
-                }
-                else {
-                    I = (GrB_Index*) java_is;
-                }
+                I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
                 // OPTIONAL STUFF
                 GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;
@@ -1045,12 +1035,7 @@ long check_grb_error(GrB_Info info);
                 jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 long java_min = -9223372036854775808;
 
-                if (java_is[0] == java_min) {
-                    I = GrB_ALL;
-                }
-                else {
-                    I = (GrB_Index*) java_is;
-                }
+                I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
                 // OPTIONAL STUFF
                 GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;
@@ -1077,12 +1062,7 @@ long check_grb_error(GrB_Info info);
                 jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 long java_min = -9223372036854775808;
 
-                if (java_is[0] == java_min) {
-                    I = GrB_ALL;
-                }
-                else {
-                    I = (GrB_Index*) java_is;
-                }
+                I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
                 // OPTIONAL STUFF
                 GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;
@@ -1109,12 +1089,7 @@ long check_grb_error(GrB_Info info);
                 jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 long java_min = -9223372036854775808;
 
-                if (java_is[0] == java_min) {
-                    I = GrB_ALL;
-                }
-                else {
-                    I = (GrB_Index*) java_is;
-                }
+                I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
                 // OPTIONAL STUFF
                 GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;
@@ -1141,12 +1116,7 @@ long check_grb_error(GrB_Info info);
                 jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 long java_min = -9223372036854775808;
 
-                if (java_is[0] == java_min) {
-                    I = GrB_ALL;
-                }
-                else {
-                    I = (GrB_Index*) java_is;
-                }
+                I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
                 // OPTIONAL STUFF
                 GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;
@@ -1173,12 +1143,7 @@ long check_grb_error(GrB_Info info);
                 jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 long java_min = -9223372036854775808;
 
-                if (java_is[0] == java_min) {
-                    I = GrB_ALL;
-                }
-                else {
-                    I = (GrB_Index*) java_is;
-                }
+                I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
                 // OPTIONAL STUFF
                 GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;

--- a/graphblas-java/src/main/c/unsafe_gen.c
+++ b/graphblas-java/src/main/c/unsafe_gen.c
@@ -90,6 +90,10 @@ long check_grb_error(GrB_Info info);
                 GrB_Index * java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
+                if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long res = check_grb_error(GrB_Matrix_extractTuples_BOOL(java_is, java_js, elms, &nvals, A));
 
                 // JNI tell Java we're done
@@ -107,6 +111,10 @@ long check_grb_error(GrB_Info info);
 
                 jboolean *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
 
                 long res = check_grb_error(GrB_Vector_extractTuples_BOOL(java_is, elms, &nvals, A));
 
@@ -126,6 +134,10 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
+                if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long res = check_grb_error(GrB_Matrix_build_BOOL(A, java_is, java_js, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
@@ -142,6 +154,10 @@ long check_grb_error(GrB_Info info);
 
                 jboolean *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
 
                 long res = check_grb_error(GrB_Vector_build_BOOL(A, java_is, elms, nvals, dup));
                 // JNI tell Java we're done
@@ -188,6 +204,10 @@ long check_grb_error(GrB_Info info);
                 GrB_Index * java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
+                if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long res = check_grb_error(GrB_Matrix_extractTuples_INT8(java_is, java_js, elms, &nvals, A));
 
                 // JNI tell Java we're done
@@ -205,6 +225,10 @@ long check_grb_error(GrB_Info info);
 
                 jbyte *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
 
                 long res = check_grb_error(GrB_Vector_extractTuples_INT8(java_is, elms, &nvals, A));
 
@@ -224,6 +248,10 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
+                if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long res = check_grb_error(GrB_Matrix_build_INT8(A, java_is, java_js, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
@@ -240,6 +268,10 @@ long check_grb_error(GrB_Info info);
 
                 jbyte *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
 
                 long res = check_grb_error(GrB_Vector_build_INT8(A, java_is, elms, nvals, dup));
                 // JNI tell Java we're done
@@ -286,6 +318,10 @@ long check_grb_error(GrB_Info info);
                 GrB_Index * java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
+                if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long res = check_grb_error(GrB_Matrix_extractTuples_INT16(java_is, java_js, elms, &nvals, A));
 
                 // JNI tell Java we're done
@@ -303,6 +339,10 @@ long check_grb_error(GrB_Info info);
 
                 jshort *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
 
                 long res = check_grb_error(GrB_Vector_extractTuples_INT16(java_is, elms, &nvals, A));
 
@@ -322,6 +362,10 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
+                if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long res = check_grb_error(GrB_Matrix_build_INT16(A, java_is, java_js, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
@@ -338,6 +382,10 @@ long check_grb_error(GrB_Info info);
 
                 jshort *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
 
                 long res = check_grb_error(GrB_Vector_build_INT16(A, java_is, elms, nvals, dup));
                 // JNI tell Java we're done
@@ -384,6 +432,10 @@ long check_grb_error(GrB_Info info);
                 GrB_Index * java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
+                if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long res = check_grb_error(GrB_Matrix_extractTuples_INT32(java_is, java_js, elms, &nvals, A));
 
                 // JNI tell Java we're done
@@ -401,6 +453,10 @@ long check_grb_error(GrB_Info info);
 
                 jint *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
 
                 long res = check_grb_error(GrB_Vector_extractTuples_INT32(java_is, elms, &nvals, A));
 
@@ -420,6 +476,10 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
+                if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long res = check_grb_error(GrB_Matrix_build_INT32(A, java_is, java_js, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
@@ -436,6 +496,10 @@ long check_grb_error(GrB_Info info);
 
                 jint *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
 
                 long res = check_grb_error(GrB_Vector_build_INT32(A, java_is, elms, nvals, dup));
                 // JNI tell Java we're done
@@ -482,6 +546,10 @@ long check_grb_error(GrB_Info info);
                 GrB_Index * java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
+                if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long res = check_grb_error(GrB_Matrix_extractTuples_INT64(java_is, java_js, elms, &nvals, A));
 
                 // JNI tell Java we're done
@@ -499,6 +567,10 @@ long check_grb_error(GrB_Info info);
 
                 jlong *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
 
                 long res = check_grb_error(GrB_Vector_extractTuples_INT64(java_is, elms, &nvals, A));
 
@@ -518,6 +590,10 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
+                if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long res = check_grb_error(GrB_Matrix_build_INT64(A, java_is, java_js, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
@@ -534,6 +610,10 @@ long check_grb_error(GrB_Info info);
 
                 jlong *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
 
                 long res = check_grb_error(GrB_Vector_build_INT64(A, java_is, elms, nvals, dup));
                 // JNI tell Java we're done
@@ -580,6 +660,10 @@ long check_grb_error(GrB_Info info);
                 GrB_Index * java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
+                if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long res = check_grb_error(GrB_Matrix_extractTuples_FP32(java_is, java_js, elms, &nvals, A));
 
                 // JNI tell Java we're done
@@ -597,6 +681,10 @@ long check_grb_error(GrB_Info info);
 
                 jfloat *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
 
                 long res = check_grb_error(GrB_Vector_extractTuples_FP32(java_is, elms, &nvals, A));
 
@@ -616,6 +704,10 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
+                if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long res = check_grb_error(GrB_Matrix_build_FP32(A, java_is, java_js, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
@@ -632,6 +724,10 @@ long check_grb_error(GrB_Info info);
 
                 jfloat *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
 
                 long res = check_grb_error(GrB_Vector_build_FP32(A, java_is, elms, nvals, dup));
                 // JNI tell Java we're done
@@ -678,6 +774,10 @@ long check_grb_error(GrB_Info info);
                 GrB_Index * java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
+                if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long res = check_grb_error(GrB_Matrix_extractTuples_FP64(java_is, java_js, elms, &nvals, A));
 
                 // JNI tell Java we're done
@@ -695,6 +795,10 @@ long check_grb_error(GrB_Info info);
 
                 jdouble *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
 
                 long res = check_grb_error(GrB_Vector_extractTuples_FP64(java_is, elms, &nvals, A));
 
@@ -714,6 +818,10 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
+                if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long res = check_grb_error(GrB_Matrix_build_FP64(A, java_is, java_js, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
@@ -730,6 +838,10 @@ long check_grb_error(GrB_Info info);
 
                 jdouble *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
 
                 long res = check_grb_error(GrB_Vector_build_FP64(A, java_is, elms, nvals, dup));
                 // JNI tell Java we're done
@@ -920,12 +1032,16 @@ long check_grb_error(GrB_Info info);
                 // NON OPTIONAL STUFF
                 GrB_Vector w = (GrB_Vector) (*env)->GetDirectBufferAddress(env, vec);
 
-                GrB_Index* I = NULL;
                 GrB_Index grb_ni = (GrB_Index) ni;
                 jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long java_min = -9223372036854775808;
 
-                I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
+                GrB_Index *I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
                 // OPTIONAL STUFF
                 GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;
@@ -947,12 +1063,16 @@ long check_grb_error(GrB_Info info);
                 // NON OPTIONAL STUFF
                 GrB_Vector w = (GrB_Vector) (*env)->GetDirectBufferAddress(env, vec);
 
-                GrB_Index* I = NULL;
                 GrB_Index grb_ni = (GrB_Index) ni;
                 jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long java_min = -9223372036854775808;
 
-                I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
+                GrB_Index *I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
                 // OPTIONAL STUFF
                 GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;
@@ -974,12 +1094,16 @@ long check_grb_error(GrB_Info info);
                 // NON OPTIONAL STUFF
                 GrB_Vector w = (GrB_Vector) (*env)->GetDirectBufferAddress(env, vec);
 
-                GrB_Index* I = NULL;
                 GrB_Index grb_ni = (GrB_Index) ni;
                 jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long java_min = -9223372036854775808;
 
-                I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
+                GrB_Index *I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
                 // OPTIONAL STUFF
                 GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;
@@ -1001,12 +1125,16 @@ long check_grb_error(GrB_Info info);
                 // NON OPTIONAL STUFF
                 GrB_Vector w = (GrB_Vector) (*env)->GetDirectBufferAddress(env, vec);
 
-                GrB_Index* I = NULL;
                 GrB_Index grb_ni = (GrB_Index) ni;
                 jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long java_min = -9223372036854775808;
 
-                I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
+                GrB_Index *I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
                 // OPTIONAL STUFF
                 GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;
@@ -1028,12 +1156,16 @@ long check_grb_error(GrB_Info info);
                 // NON OPTIONAL STUFF
                 GrB_Vector w = (GrB_Vector) (*env)->GetDirectBufferAddress(env, vec);
 
-                GrB_Index* I = NULL;
                 GrB_Index grb_ni = (GrB_Index) ni;
                 jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long java_min = -9223372036854775808;
 
-                I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
+                GrB_Index *I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
                 // OPTIONAL STUFF
                 GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;
@@ -1055,12 +1187,16 @@ long check_grb_error(GrB_Info info);
                 // NON OPTIONAL STUFF
                 GrB_Vector w = (GrB_Vector) (*env)->GetDirectBufferAddress(env, vec);
 
-                GrB_Index* I = NULL;
                 GrB_Index grb_ni = (GrB_Index) ni;
                 jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long java_min = -9223372036854775808;
 
-                I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
+                GrB_Index *I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
                 // OPTIONAL STUFF
                 GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;
@@ -1082,12 +1218,16 @@ long check_grb_error(GrB_Info info);
                 // NON OPTIONAL STUFF
                 GrB_Vector w = (GrB_Vector) (*env)->GetDirectBufferAddress(env, vec);
 
-                GrB_Index* I = NULL;
                 GrB_Index grb_ni = (GrB_Index) ni;
                 jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long java_min = -9223372036854775808;
 
-                I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
+                GrB_Index *I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
                 // OPTIONAL STUFF
                 GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;

--- a/graphblas-java/src/main/c/unsafe_gen.c
+++ b/graphblas-java/src/main/c/unsafe_gen.c
@@ -126,7 +126,7 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
-                long res = GrB_Matrix_build_BOOL(A, java_is, java_js, elms, nvals, dup);
+                long res = check_grb_error(GrB_Matrix_build_BOOL(A, java_is, java_js, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
                 (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
@@ -143,7 +143,7 @@ long check_grb_error(GrB_Info info);
                 jboolean *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
-                long res = GrB_Vector_build_BOOL(A, java_is, elms, nvals, dup);
+                long res = check_grb_error(GrB_Vector_build_BOOL(A, java_is, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
                 (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
@@ -224,7 +224,7 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
-                long res = GrB_Matrix_build_INT8(A, java_is, java_js, elms, nvals, dup);
+                long res = check_grb_error(GrB_Matrix_build_INT8(A, java_is, java_js, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
                 (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
@@ -241,7 +241,7 @@ long check_grb_error(GrB_Info info);
                 jbyte *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
-                long res = GrB_Vector_build_INT8(A, java_is, elms, nvals, dup);
+                long res = check_grb_error(GrB_Vector_build_INT8(A, java_is, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
                 (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
@@ -322,7 +322,7 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
-                long res = GrB_Matrix_build_INT16(A, java_is, java_js, elms, nvals, dup);
+                long res = check_grb_error(GrB_Matrix_build_INT16(A, java_is, java_js, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
                 (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
@@ -339,7 +339,7 @@ long check_grb_error(GrB_Info info);
                 jshort *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
-                long res = GrB_Vector_build_INT16(A, java_is, elms, nvals, dup);
+                long res = check_grb_error(GrB_Vector_build_INT16(A, java_is, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
                 (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
@@ -420,7 +420,7 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
-                long res = GrB_Matrix_build_INT32(A, java_is, java_js, elms, nvals, dup);
+                long res = check_grb_error(GrB_Matrix_build_INT32(A, java_is, java_js, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
                 (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
@@ -437,7 +437,7 @@ long check_grb_error(GrB_Info info);
                 jint *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
-                long res = GrB_Vector_build_INT32(A, java_is, elms, nvals, dup);
+                long res = check_grb_error(GrB_Vector_build_INT32(A, java_is, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
                 (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
@@ -518,7 +518,7 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
-                long res = GrB_Matrix_build_INT64(A, java_is, java_js, elms, nvals, dup);
+                long res = check_grb_error(GrB_Matrix_build_INT64(A, java_is, java_js, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
                 (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
@@ -535,7 +535,7 @@ long check_grb_error(GrB_Info info);
                 jlong *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
-                long res = GrB_Vector_build_INT64(A, java_is, elms, nvals, dup);
+                long res = check_grb_error(GrB_Vector_build_INT64(A, java_is, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
                 (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
@@ -616,7 +616,7 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
-                long res = GrB_Matrix_build_FP32(A, java_is, java_js, elms, nvals, dup);
+                long res = check_grb_error(GrB_Matrix_build_FP32(A, java_is, java_js, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
                 (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
@@ -633,7 +633,7 @@ long check_grb_error(GrB_Info info);
                 jfloat *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
-                long res = GrB_Vector_build_FP32(A, java_is, elms, nvals, dup);
+                long res = check_grb_error(GrB_Vector_build_FP32(A, java_is, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
                 (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
@@ -714,7 +714,7 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
-                long res = GrB_Matrix_build_FP64(A, java_is, java_js, elms, nvals, dup);
+                long res = check_grb_error(GrB_Matrix_build_FP64(A, java_is, java_js, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
                 (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
@@ -731,7 +731,7 @@ long check_grb_error(GrB_Info info);
                 jdouble *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
-                long res = GrB_Vector_build_FP64(A, java_is, elms, nvals, dup);
+                long res = check_grb_error(GrB_Vector_build_FP64(A, java_is, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
                 (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);

--- a/graphblas-java/src/main/c/unsafe_gen.c
+++ b/graphblas-java/src/main/c/unsafe_gen.c
@@ -91,6 +91,18 @@ long check_grb_error(GrB_Info info);
                 GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
+                    if(java_js != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -113,6 +125,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 if (java_is == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -135,6 +155,18 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
+                    if(java_js != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -156,6 +188,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 if (java_is == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -205,6 +245,18 @@ long check_grb_error(GrB_Info info);
                 GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
+                    if(java_js != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -227,6 +279,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 if (java_is == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -249,6 +309,18 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
+                    if(java_js != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -270,6 +342,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 if (java_is == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -319,6 +399,18 @@ long check_grb_error(GrB_Info info);
                 GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
+                    if(java_js != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -341,6 +433,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 if (java_is == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -363,6 +463,18 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
+                    if(java_js != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -384,6 +496,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 if (java_is == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -433,6 +553,18 @@ long check_grb_error(GrB_Info info);
                 GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
+                    if(java_js != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -455,6 +587,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 if (java_is == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -477,6 +617,18 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
+                    if(java_js != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -498,6 +650,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 if (java_is == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -547,6 +707,18 @@ long check_grb_error(GrB_Info info);
                 GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
+                    if(java_js != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -569,6 +741,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 if (java_is == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -591,6 +771,18 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
+                    if(java_js != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -612,6 +804,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 if (java_is == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -661,6 +861,18 @@ long check_grb_error(GrB_Info info);
                 GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
+                    if(java_js != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -683,6 +895,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 if (java_is == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -705,6 +925,18 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
+                    if(java_js != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -726,6 +958,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 if (java_is == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -775,6 +1015,18 @@ long check_grb_error(GrB_Info info);
                 GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
+                    if(java_js != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -797,6 +1049,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 if (java_is == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -819,6 +1079,18 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
+                    if(java_js != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -840,6 +1112,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 if (java_is == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 

--- a/graphblas-java/src/main/c/unsafe_gen.c
+++ b/graphblas-java/src/main/c/unsafe_gen.c
@@ -122,17 +122,9 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                bool cV;
-                bool cI;
-                bool cJ;
-
-                jboolean* elms = (*env)->GetPrimitiveArrayCritical(env, vs, &cV);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, &cI);
-                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, &cJ);
-
-                printf("Values copied? %d \n", cV) ;
-                printf("Is copied? %d \n", cI) ;
-                printf("Js copied? %d \n", cJ) ;
+                jboolean* elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 long res = GrB_Matrix_build_BOOL(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
@@ -228,17 +220,9 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                bool cV;
-                bool cI;
-                bool cJ;
-
-                jbyte* elms = (*env)->GetPrimitiveArrayCritical(env, vs, &cV);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, &cI);
-                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, &cJ);
-
-                printf("Values copied? %d \n", cV) ;
-                printf("Is copied? %d \n", cI) ;
-                printf("Js copied? %d \n", cJ) ;
+                jbyte* elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 long res = GrB_Matrix_build_INT8(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
@@ -334,17 +318,9 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                bool cV;
-                bool cI;
-                bool cJ;
-
-                jshort* elms = (*env)->GetPrimitiveArrayCritical(env, vs, &cV);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, &cI);
-                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, &cJ);
-
-                printf("Values copied? %d \n", cV) ;
-                printf("Is copied? %d \n", cI) ;
-                printf("Js copied? %d \n", cJ) ;
+                jshort* elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 long res = GrB_Matrix_build_INT16(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
@@ -440,17 +416,9 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                bool cV;
-                bool cI;
-                bool cJ;
-
-                jint* elms = (*env)->GetPrimitiveArrayCritical(env, vs, &cV);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, &cI);
-                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, &cJ);
-
-                printf("Values copied? %d \n", cV) ;
-                printf("Is copied? %d \n", cI) ;
-                printf("Js copied? %d \n", cJ) ;
+                jint* elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 long res = GrB_Matrix_build_INT32(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
@@ -546,17 +514,9 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                bool cV;
-                bool cI;
-                bool cJ;
-
-                jlong* elms = (*env)->GetPrimitiveArrayCritical(env, vs, &cV);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, &cI);
-                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, &cJ);
-
-                printf("Values copied? %d \n", cV) ;
-                printf("Is copied? %d \n", cI) ;
-                printf("Js copied? %d \n", cJ) ;
+                jlong* elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 long res = GrB_Matrix_build_INT64(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
@@ -652,17 +612,9 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                bool cV;
-                bool cI;
-                bool cJ;
-
-                jfloat* elms = (*env)->GetPrimitiveArrayCritical(env, vs, &cV);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, &cI);
-                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, &cJ);
-
-                printf("Values copied? %d \n", cV) ;
-                printf("Is copied? %d \n", cI) ;
-                printf("Js copied? %d \n", cJ) ;
+                jfloat* elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 long res = GrB_Matrix_build_FP32(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
@@ -758,17 +710,9 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                bool cV;
-                bool cI;
-                bool cJ;
-
-                jdouble* elms = (*env)->GetPrimitiveArrayCritical(env, vs, &cV);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, &cI);
-                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, &cJ);
-
-                printf("Values copied? %d \n", cV) ;
-                printf("Is copied? %d \n", cI) ;
-                printf("Js copied? %d \n", cJ) ;
+                jdouble* elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 long res = GrB_Matrix_build_FP64(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done

--- a/graphblas-java/src/main/c/unsafe_gen.c
+++ b/graphblas-java/src/main/c/unsafe_gen.c
@@ -86,16 +86,16 @@ long check_grb_error(GrB_Info info);
                 GrB_Index nvals;
                 GrB_Matrix_nvals(&nvals, A);
 
-                jboolean *elms = (*env)->GetBooleanArrayElements(env, vs, NULL);
-                GrB_Index * java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
-                GrB_Index * java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, NULL);
+                jboolean *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index * java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+                GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 long res = check_grb_error(GrB_Matrix_extractTuples_BOOL(java_is, java_js, elms, &nvals, A));
 
                 // JNI tell Java we're done
-                (*env)->ReleaseBooleanArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
                 return res;
               }
 
@@ -105,14 +105,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index nvals;
                 GrB_Vector_nvals(&nvals, A);
 
-                jboolean *elms = (*env)->GetBooleanArrayElements(env, vs, NULL);
-                GrB_Index *java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                jboolean *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 long res = check_grb_error(GrB_Vector_extractTuples_BOOL(java_is, elms, &nvals, A));
 
                 // JNI tell Java we're done
-                (*env)->ReleaseBooleanArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
                 return res;
               }
 
@@ -126,9 +126,9 @@ long check_grb_error(GrB_Info info);
                 bool cI;
                 bool cJ;
 
-                jboolean* elms = (*env)->GetBooleanArrayElements(env, vs, &cV);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, &cI);
-                GrB_Index* java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, &cJ);
+                jboolean* elms = (*env)->GetPrimitiveArrayCritical(env, vs, &cV);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, &cI);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, &cJ);
 
                 printf("Values copied? %d \n", cV) ;
                 printf("Is copied? %d \n", cI) ;
@@ -136,9 +136,9 @@ long check_grb_error(GrB_Info info);
 
                 long res = GrB_Matrix_build_BOOL(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
-                (*env)->ReleaseBooleanArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
                 return res;
               }
 
@@ -148,13 +148,13 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jboolean *elms = (*env)->GetBooleanArrayElements(env, vs, NULL);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                jboolean *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 long res = GrB_Vector_build_BOOL(A, java_is, elms, nvals, dup);
                 // JNI tell Java we're done
-                (*env)->ReleaseBooleanArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
                 return res;
               }
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setMatrixElementByte
@@ -192,16 +192,16 @@ long check_grb_error(GrB_Info info);
                 GrB_Index nvals;
                 GrB_Matrix_nvals(&nvals, A);
 
-                jbyte *elms = (*env)->GetByteArrayElements(env, vs, NULL);
-                GrB_Index * java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
-                GrB_Index * java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, NULL);
+                jbyte *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index * java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+                GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 long res = check_grb_error(GrB_Matrix_extractTuples_INT8(java_is, java_js, elms, &nvals, A));
 
                 // JNI tell Java we're done
-                (*env)->ReleaseByteArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
                 return res;
               }
 
@@ -211,14 +211,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index nvals;
                 GrB_Vector_nvals(&nvals, A);
 
-                jbyte *elms = (*env)->GetByteArrayElements(env, vs, NULL);
-                GrB_Index *java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                jbyte *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 long res = check_grb_error(GrB_Vector_extractTuples_INT8(java_is, elms, &nvals, A));
 
                 // JNI tell Java we're done
-                (*env)->ReleaseByteArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
                 return res;
               }
 
@@ -232,9 +232,9 @@ long check_grb_error(GrB_Info info);
                 bool cI;
                 bool cJ;
 
-                jbyte* elms = (*env)->GetByteArrayElements(env, vs, &cV);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, &cI);
-                GrB_Index* java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, &cJ);
+                jbyte* elms = (*env)->GetPrimitiveArrayCritical(env, vs, &cV);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, &cI);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, &cJ);
 
                 printf("Values copied? %d \n", cV) ;
                 printf("Is copied? %d \n", cI) ;
@@ -242,9 +242,9 @@ long check_grb_error(GrB_Info info);
 
                 long res = GrB_Matrix_build_INT8(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
-                (*env)->ReleaseByteArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
                 return res;
               }
 
@@ -254,13 +254,13 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jbyte *elms = (*env)->GetByteArrayElements(env, vs, NULL);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                jbyte *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 long res = GrB_Vector_build_INT8(A, java_is, elms, nvals, dup);
                 // JNI tell Java we're done
-                (*env)->ReleaseByteArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
                 return res;
               }
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setMatrixElementShort
@@ -298,16 +298,16 @@ long check_grb_error(GrB_Info info);
                 GrB_Index nvals;
                 GrB_Matrix_nvals(&nvals, A);
 
-                jshort *elms = (*env)->GetShortArrayElements(env, vs, NULL);
-                GrB_Index * java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
-                GrB_Index * java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, NULL);
+                jshort *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index * java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+                GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 long res = check_grb_error(GrB_Matrix_extractTuples_INT16(java_is, java_js, elms, &nvals, A));
 
                 // JNI tell Java we're done
-                (*env)->ReleaseShortArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
                 return res;
               }
 
@@ -317,14 +317,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index nvals;
                 GrB_Vector_nvals(&nvals, A);
 
-                jshort *elms = (*env)->GetShortArrayElements(env, vs, NULL);
-                GrB_Index *java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                jshort *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 long res = check_grb_error(GrB_Vector_extractTuples_INT16(java_is, elms, &nvals, A));
 
                 // JNI tell Java we're done
-                (*env)->ReleaseShortArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
                 return res;
               }
 
@@ -338,9 +338,9 @@ long check_grb_error(GrB_Info info);
                 bool cI;
                 bool cJ;
 
-                jshort* elms = (*env)->GetShortArrayElements(env, vs, &cV);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, &cI);
-                GrB_Index* java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, &cJ);
+                jshort* elms = (*env)->GetPrimitiveArrayCritical(env, vs, &cV);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, &cI);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, &cJ);
 
                 printf("Values copied? %d \n", cV) ;
                 printf("Is copied? %d \n", cI) ;
@@ -348,9 +348,9 @@ long check_grb_error(GrB_Info info);
 
                 long res = GrB_Matrix_build_INT16(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
-                (*env)->ReleaseShortArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
                 return res;
               }
 
@@ -360,13 +360,13 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jshort *elms = (*env)->GetShortArrayElements(env, vs, NULL);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                jshort *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 long res = GrB_Vector_build_INT16(A, java_is, elms, nvals, dup);
                 // JNI tell Java we're done
-                (*env)->ReleaseShortArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
                 return res;
               }
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setMatrixElementInt
@@ -404,16 +404,16 @@ long check_grb_error(GrB_Info info);
                 GrB_Index nvals;
                 GrB_Matrix_nvals(&nvals, A);
 
-                jint *elms = (*env)->GetIntArrayElements(env, vs, NULL);
-                GrB_Index * java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
-                GrB_Index * java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, NULL);
+                jint *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index * java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+                GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 long res = check_grb_error(GrB_Matrix_extractTuples_INT32(java_is, java_js, elms, &nvals, A));
 
                 // JNI tell Java we're done
-                (*env)->ReleaseIntArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
                 return res;
               }
 
@@ -423,14 +423,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index nvals;
                 GrB_Vector_nvals(&nvals, A);
 
-                jint *elms = (*env)->GetIntArrayElements(env, vs, NULL);
-                GrB_Index *java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                jint *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 long res = check_grb_error(GrB_Vector_extractTuples_INT32(java_is, elms, &nvals, A));
 
                 // JNI tell Java we're done
-                (*env)->ReleaseIntArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
                 return res;
               }
 
@@ -444,9 +444,9 @@ long check_grb_error(GrB_Info info);
                 bool cI;
                 bool cJ;
 
-                jint* elms = (*env)->GetIntArrayElements(env, vs, &cV);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, &cI);
-                GrB_Index* java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, &cJ);
+                jint* elms = (*env)->GetPrimitiveArrayCritical(env, vs, &cV);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, &cI);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, &cJ);
 
                 printf("Values copied? %d \n", cV) ;
                 printf("Is copied? %d \n", cI) ;
@@ -454,9 +454,9 @@ long check_grb_error(GrB_Info info);
 
                 long res = GrB_Matrix_build_INT32(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
-                (*env)->ReleaseIntArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
                 return res;
               }
 
@@ -466,13 +466,13 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jint *elms = (*env)->GetIntArrayElements(env, vs, NULL);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                jint *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 long res = GrB_Vector_build_INT32(A, java_is, elms, nvals, dup);
                 // JNI tell Java we're done
-                (*env)->ReleaseIntArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
                 return res;
               }
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setMatrixElementLong
@@ -510,16 +510,16 @@ long check_grb_error(GrB_Info info);
                 GrB_Index nvals;
                 GrB_Matrix_nvals(&nvals, A);
 
-                jlong *elms = (*env)->GetLongArrayElements(env, vs, NULL);
-                GrB_Index * java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
-                GrB_Index * java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, NULL);
+                jlong *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index * java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+                GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 long res = check_grb_error(GrB_Matrix_extractTuples_INT64(java_is, java_js, elms, &nvals, A));
 
                 // JNI tell Java we're done
-                (*env)->ReleaseLongArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
                 return res;
               }
 
@@ -529,14 +529,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index nvals;
                 GrB_Vector_nvals(&nvals, A);
 
-                jlong *elms = (*env)->GetLongArrayElements(env, vs, NULL);
-                GrB_Index *java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                jlong *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 long res = check_grb_error(GrB_Vector_extractTuples_INT64(java_is, elms, &nvals, A));
 
                 // JNI tell Java we're done
-                (*env)->ReleaseLongArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
                 return res;
               }
 
@@ -550,9 +550,9 @@ long check_grb_error(GrB_Info info);
                 bool cI;
                 bool cJ;
 
-                jlong* elms = (*env)->GetLongArrayElements(env, vs, &cV);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, &cI);
-                GrB_Index* java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, &cJ);
+                jlong* elms = (*env)->GetPrimitiveArrayCritical(env, vs, &cV);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, &cI);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, &cJ);
 
                 printf("Values copied? %d \n", cV) ;
                 printf("Is copied? %d \n", cI) ;
@@ -560,9 +560,9 @@ long check_grb_error(GrB_Info info);
 
                 long res = GrB_Matrix_build_INT64(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
-                (*env)->ReleaseLongArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
                 return res;
               }
 
@@ -572,13 +572,13 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jlong *elms = (*env)->GetLongArrayElements(env, vs, NULL);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                jlong *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 long res = GrB_Vector_build_INT64(A, java_is, elms, nvals, dup);
                 // JNI tell Java we're done
-                (*env)->ReleaseLongArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
                 return res;
               }
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setMatrixElementFloat
@@ -616,16 +616,16 @@ long check_grb_error(GrB_Info info);
                 GrB_Index nvals;
                 GrB_Matrix_nvals(&nvals, A);
 
-                jfloat *elms = (*env)->GetFloatArrayElements(env, vs, NULL);
-                GrB_Index * java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
-                GrB_Index * java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, NULL);
+                jfloat *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index * java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+                GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 long res = check_grb_error(GrB_Matrix_extractTuples_FP32(java_is, java_js, elms, &nvals, A));
 
                 // JNI tell Java we're done
-                (*env)->ReleaseFloatArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
                 return res;
               }
 
@@ -635,14 +635,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index nvals;
                 GrB_Vector_nvals(&nvals, A);
 
-                jfloat *elms = (*env)->GetFloatArrayElements(env, vs, NULL);
-                GrB_Index *java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                jfloat *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 long res = check_grb_error(GrB_Vector_extractTuples_FP32(java_is, elms, &nvals, A));
 
                 // JNI tell Java we're done
-                (*env)->ReleaseFloatArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
                 return res;
               }
 
@@ -656,9 +656,9 @@ long check_grb_error(GrB_Info info);
                 bool cI;
                 bool cJ;
 
-                jfloat* elms = (*env)->GetFloatArrayElements(env, vs, &cV);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, &cI);
-                GrB_Index* java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, &cJ);
+                jfloat* elms = (*env)->GetPrimitiveArrayCritical(env, vs, &cV);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, &cI);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, &cJ);
 
                 printf("Values copied? %d \n", cV) ;
                 printf("Is copied? %d \n", cI) ;
@@ -666,9 +666,9 @@ long check_grb_error(GrB_Info info);
 
                 long res = GrB_Matrix_build_FP32(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
-                (*env)->ReleaseFloatArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
                 return res;
               }
 
@@ -678,13 +678,13 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jfloat *elms = (*env)->GetFloatArrayElements(env, vs, NULL);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                jfloat *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 long res = GrB_Vector_build_FP32(A, java_is, elms, nvals, dup);
                 // JNI tell Java we're done
-                (*env)->ReleaseFloatArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
                 return res;
               }
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setMatrixElementDouble
@@ -722,16 +722,16 @@ long check_grb_error(GrB_Info info);
                 GrB_Index nvals;
                 GrB_Matrix_nvals(&nvals, A);
 
-                jdouble *elms = (*env)->GetDoubleArrayElements(env, vs, NULL);
-                GrB_Index * java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
-                GrB_Index * java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, NULL);
+                jdouble *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index * java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+                GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 long res = check_grb_error(GrB_Matrix_extractTuples_FP64(java_is, java_js, elms, &nvals, A));
 
                 // JNI tell Java we're done
-                (*env)->ReleaseDoubleArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
                 return res;
               }
 
@@ -741,14 +741,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index nvals;
                 GrB_Vector_nvals(&nvals, A);
 
-                jdouble *elms = (*env)->GetDoubleArrayElements(env, vs, NULL);
-                GrB_Index *java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                jdouble *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 long res = check_grb_error(GrB_Vector_extractTuples_FP64(java_is, elms, &nvals, A));
 
                 // JNI tell Java we're done
-                (*env)->ReleaseDoubleArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
                 return res;
               }
 
@@ -762,9 +762,9 @@ long check_grb_error(GrB_Info info);
                 bool cI;
                 bool cJ;
 
-                jdouble* elms = (*env)->GetDoubleArrayElements(env, vs, &cV);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, &cI);
-                GrB_Index* java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, &cJ);
+                jdouble* elms = (*env)->GetPrimitiveArrayCritical(env, vs, &cV);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, &cI);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, &cJ);
 
                 printf("Values copied? %d \n", cV) ;
                 printf("Is copied? %d \n", cI) ;
@@ -772,9 +772,9 @@ long check_grb_error(GrB_Info info);
 
                 long res = GrB_Matrix_build_FP64(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
-                (*env)->ReleaseDoubleArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
                 return res;
               }
 
@@ -784,13 +784,13 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jdouble *elms = (*env)->GetDoubleArrayElements(env, vs, NULL);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                jdouble *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 long res = GrB_Vector_build_FP64(A, java_is, elms, nvals, dup);
                 // JNI tell Java we're done
-                (*env)->ReleaseDoubleArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
                 return res;
               }
 
@@ -978,19 +978,14 @@ long check_grb_error(GrB_Info info);
 
                 GrB_Index* I = NULL;
                 GrB_Index grb_ni = (GrB_Index) ni;
-                jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 long java_min = -9223372036854775808;
 
                 if (java_is[0] == java_min) {
                     I = GrB_ALL;
                 }
                 else {
-                    I = malloc (grb_ni * sizeof (GrB_Index));
-
-                    // just copy :(
-                    for (int i = 0; i < grb_ni; i++) {
-                        I[i] = (GrB_Index)java_is[i];
-                    }
+                    I = (GrB_Index*) java_is;
                 }
 
                 // OPTIONAL STUFF
@@ -1001,10 +996,7 @@ long check_grb_error(GrB_Info info);
 
                 long res = check_grb_error(GrB_Vector_assign_BOOL(w, m, acc, value, I, grb_ni, d));
 
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                if(I != GrB_ALL) {
-                    free(I);
-                }
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
 
                 return res;
                 }
@@ -1018,19 +1010,14 @@ long check_grb_error(GrB_Info info);
 
                 GrB_Index* I = NULL;
                 GrB_Index grb_ni = (GrB_Index) ni;
-                jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 long java_min = -9223372036854775808;
 
                 if (java_is[0] == java_min) {
                     I = GrB_ALL;
                 }
                 else {
-                    I = malloc (grb_ni * sizeof (GrB_Index));
-
-                    // just copy :(
-                    for (int i = 0; i < grb_ni; i++) {
-                        I[i] = (GrB_Index)java_is[i];
-                    }
+                    I = (GrB_Index*) java_is;
                 }
 
                 // OPTIONAL STUFF
@@ -1041,10 +1028,7 @@ long check_grb_error(GrB_Info info);
 
                 long res = check_grb_error(GrB_Vector_assign_INT8(w, m, acc, value, I, grb_ni, d));
 
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                if(I != GrB_ALL) {
-                    free(I);
-                }
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
 
                 return res;
                 }
@@ -1058,19 +1042,14 @@ long check_grb_error(GrB_Info info);
 
                 GrB_Index* I = NULL;
                 GrB_Index grb_ni = (GrB_Index) ni;
-                jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 long java_min = -9223372036854775808;
 
                 if (java_is[0] == java_min) {
                     I = GrB_ALL;
                 }
                 else {
-                    I = malloc (grb_ni * sizeof (GrB_Index));
-
-                    // just copy :(
-                    for (int i = 0; i < grb_ni; i++) {
-                        I[i] = (GrB_Index)java_is[i];
-                    }
+                    I = (GrB_Index*) java_is;
                 }
 
                 // OPTIONAL STUFF
@@ -1081,10 +1060,7 @@ long check_grb_error(GrB_Info info);
 
                 long res = check_grb_error(GrB_Vector_assign_INT16(w, m, acc, value, I, grb_ni, d));
 
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                if(I != GrB_ALL) {
-                    free(I);
-                }
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
 
                 return res;
                 }
@@ -1098,19 +1074,14 @@ long check_grb_error(GrB_Info info);
 
                 GrB_Index* I = NULL;
                 GrB_Index grb_ni = (GrB_Index) ni;
-                jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 long java_min = -9223372036854775808;
 
                 if (java_is[0] == java_min) {
                     I = GrB_ALL;
                 }
                 else {
-                    I = malloc (grb_ni * sizeof (GrB_Index));
-
-                    // just copy :(
-                    for (int i = 0; i < grb_ni; i++) {
-                        I[i] = (GrB_Index)java_is[i];
-                    }
+                    I = (GrB_Index*) java_is;
                 }
 
                 // OPTIONAL STUFF
@@ -1121,10 +1092,7 @@ long check_grb_error(GrB_Info info);
 
                 long res = check_grb_error(GrB_Vector_assign_INT32(w, m, acc, value, I, grb_ni, d));
 
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                if(I != GrB_ALL) {
-                    free(I);
-                }
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
 
                 return res;
                 }
@@ -1138,19 +1106,14 @@ long check_grb_error(GrB_Info info);
 
                 GrB_Index* I = NULL;
                 GrB_Index grb_ni = (GrB_Index) ni;
-                jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 long java_min = -9223372036854775808;
 
                 if (java_is[0] == java_min) {
                     I = GrB_ALL;
                 }
                 else {
-                    I = malloc (grb_ni * sizeof (GrB_Index));
-
-                    // just copy :(
-                    for (int i = 0; i < grb_ni; i++) {
-                        I[i] = (GrB_Index)java_is[i];
-                    }
+                    I = (GrB_Index*) java_is;
                 }
 
                 // OPTIONAL STUFF
@@ -1161,10 +1124,7 @@ long check_grb_error(GrB_Info info);
 
                 long res = check_grb_error(GrB_Vector_assign_INT64(w, m, acc, value, I, grb_ni, d));
 
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                if(I != GrB_ALL) {
-                    free(I);
-                }
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
 
                 return res;
                 }
@@ -1178,19 +1138,14 @@ long check_grb_error(GrB_Info info);
 
                 GrB_Index* I = NULL;
                 GrB_Index grb_ni = (GrB_Index) ni;
-                jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 long java_min = -9223372036854775808;
 
                 if (java_is[0] == java_min) {
                     I = GrB_ALL;
                 }
                 else {
-                    I = malloc (grb_ni * sizeof (GrB_Index));
-
-                    // just copy :(
-                    for (int i = 0; i < grb_ni; i++) {
-                        I[i] = (GrB_Index)java_is[i];
-                    }
+                    I = (GrB_Index*) java_is;
                 }
 
                 // OPTIONAL STUFF
@@ -1201,10 +1156,7 @@ long check_grb_error(GrB_Info info);
 
                 long res = check_grb_error(GrB_Vector_assign_FP32(w, m, acc, value, I, grb_ni, d));
 
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                if(I != GrB_ALL) {
-                    free(I);
-                }
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
 
                 return res;
                 }
@@ -1218,19 +1170,14 @@ long check_grb_error(GrB_Info info);
 
                 GrB_Index* I = NULL;
                 GrB_Index grb_ni = (GrB_Index) ni;
-                jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 long java_min = -9223372036854775808;
 
                 if (java_is[0] == java_min) {
                     I = GrB_ALL;
                 }
                 else {
-                    I = malloc (grb_ni * sizeof (GrB_Index));
-
-                    // just copy :(
-                    for (int i = 0; i < grb_ni; i++) {
-                        I[i] = (GrB_Index)java_is[i];
-                    }
+                    I = (GrB_Index*) java_is;
                 }
 
                 // OPTIONAL STUFF
@@ -1241,10 +1188,7 @@ long check_grb_error(GrB_Info info);
 
                 long res = check_grb_error(GrB_Vector_assign_FP64(w, m, acc, value, I, grb_ni, d));
 
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                if(I != GrB_ALL) {
-                    free(I);
-                }
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
 
                 return res;
                 }

--- a/graphblas-java/src/main/c/unsafe_gen.c
+++ b/graphblas-java/src/main/c/unsafe_gen.c
@@ -11,71 +11,71 @@ long check_grb_error(GrB_Info info);
             
             JNIEXPORT jobject JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_booleanType
             (JNIEnv * env, jclass cls) {
-            return (*env)->NewDirectByteBuffer(env, GrB_BOOL, 0);
+                return (*env)->NewDirectByteBuffer(env, GrB_BOOL, 0);
             }
 
 
             JNIEXPORT jobject JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_byteType
             (JNIEnv * env, jclass cls) {
-            return (*env)->NewDirectByteBuffer(env, GrB_INT8, 0);
+                return (*env)->NewDirectByteBuffer(env, GrB_INT8, 0);
             }
 
 
             JNIEXPORT jobject JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_shortType
             (JNIEnv * env, jclass cls) {
-            return (*env)->NewDirectByteBuffer(env, GrB_INT16, 0);
+                return (*env)->NewDirectByteBuffer(env, GrB_INT16, 0);
             }
 
 
             JNIEXPORT jobject JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_intType
             (JNIEnv * env, jclass cls) {
-            return (*env)->NewDirectByteBuffer(env, GrB_INT32, 0);
+                return (*env)->NewDirectByteBuffer(env, GrB_INT32, 0);
             }
 
 
             JNIEXPORT jobject JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_longType
             (JNIEnv * env, jclass cls) {
-            return (*env)->NewDirectByteBuffer(env, GrB_INT64, 0);
+                return (*env)->NewDirectByteBuffer(env, GrB_INT64, 0);
             }
 
 
             JNIEXPORT jobject JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_floatType
             (JNIEnv * env, jclass cls) {
-            return (*env)->NewDirectByteBuffer(env, GrB_FP32, 0);
+                return (*env)->NewDirectByteBuffer(env, GrB_FP32, 0);
             }
 
 
             JNIEXPORT jobject JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_doubleType
             (JNIEnv * env, jclass cls) {
-            return (*env)->NewDirectByteBuffer(env, GrB_FP64, 0);
+                return (*env)->NewDirectByteBuffer(env, GrB_FP64, 0);
             }
 
 
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setMatrixElementBoolean
             (JNIEnv * env, jclass cls, jobject mat, jlong i, jlong j, jboolean value) {
-            GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
+                GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index I = (GrB_Index)i;
                 GrB_Index J = (GrB_Index)j;
-            return check_grb_error( GrB_Matrix_setElement_BOOL(A, value, I, J) ) ;
+                return check_grb_error( GrB_Matrix_setElement_BOOL(A, value, I, J) ) ;
             }
 
 
             JNIEXPORT jbooleanArray JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_getMatrixElementBoolean
             (JNIEnv * env, jclass cls, jobject mat, jlong i, jlong j) {
-            bool x;
-            GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
+                bool x;
+                GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index I = (GrB_Index)i;
                 GrB_Index J = (GrB_Index)j;
-            GrB_Info info = GrB_Matrix_extractElement_BOOL(&x, A, I, J);
-            jbooleanArray output;
-            if (info == GrB_NO_VALUE) {
-            output = (*env)->NewBooleanArray(env, 0);
-            } else {
-            output = (*env)->NewBooleanArray(env, 1);
-            bool xs[] = {x};
-            (*env)->SetBooleanArrayRegion(env, output, 0, 1, xs);
-            }
-            return output;
+                GrB_Info info = GrB_Matrix_extractElement_BOOL(&x, A, I, J);
+                jbooleanArray output;
+                if (info == GrB_NO_VALUE) {
+                    output = (*env)->NewBooleanArray(env, 0);
+                } else {
+                    output = (*env)->NewBooleanArray(env, 1);
+                    bool xs[] = {x};
+                    (*env)->SetBooleanArrayRegion(env, output, 0, 1, xs);
+                }
+                return output;
             }
 
 
@@ -85,30 +85,17 @@ long check_grb_error(GrB_Info info);
                 GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index nvals;
                 GrB_Matrix_nvals(&nvals, A);
-                jboolean *elms;
-                jlong *java_is;
-                jlong *java_js;
 
-                GrB_Index *I = NULL;
-                GrB_Index *J = NULL;
-                elms = (*env)->GetBooleanArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                java_js = (*env)->GetLongArrayElements(env, js, NULL);
+                jboolean *elms = (*env)->GetBooleanArrayElements(env, vs, NULL);
+                GrB_Index * java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                GrB_Index * java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, NULL);
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                J = malloc (nvals * sizeof (GrB_Index)) ;
-                long res = check_grb_error(GrB_Matrix_extractTuples_BOOL(I, J, elms, &nvals, A));
-                // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    java_is[i] = (long) I[i];
-                    java_js[i] = (long) J[i];
-                }
+                long res = check_grb_error(GrB_Matrix_extractTuples_BOOL(java_is, java_js, elms, &nvals, A));
+
                 // JNI tell Java we're done
                 (*env)->ReleaseBooleanArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-                free(I);
-                free(J);
                 return res;
               }
 
@@ -117,58 +104,41 @@ long check_grb_error(GrB_Info info);
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index nvals;
                 GrB_Vector_nvals(&nvals, A);
-                jboolean *elms;
-                jlong *java_is;
 
-                GrB_Index *I = NULL;
-                elms = (*env)->GetBooleanArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                jboolean *elms = (*env)->GetBooleanArrayElements(env, vs, NULL);
+                GrB_Index *java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                long res = check_grb_error(GrB_Vector_extractTuples_BOOL(I, elms, &nvals, A));
-                // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    java_is[i] = (long) I[i];
-                }
+                long res = check_grb_error(GrB_Vector_extractTuples_BOOL(java_is, elms, &nvals, A));
+
                 // JNI tell Java we're done
                 (*env)->ReleaseBooleanArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                free(I);
                 return res;
               }
+
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_buildMatrixFromTuplesBoolean
               (JNIEnv * env, jclass cls, jobject mat, jlongArray is, jlongArray js, jbooleanArray vs, jlong n, jobject dupOp) {
                 GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jboolean *elms;
-                jlong *java_is;
-                jlong *java_js;
+                bool cV;
+                bool cI;
+                bool cJ;
 
-                GrB_Index *I = NULL;
-                GrB_Index *J = NULL;
+                jboolean* elms = (*env)->GetBooleanArrayElements(env, vs, &cV);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, &cI);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, &cJ);
 
-                elms = (*env)->GetBooleanArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                java_js = (*env)->GetLongArrayElements(env, js, NULL);
+                printf("Values copied? %d \n", cV) ;
+                printf("Is copied? %d \n", cI) ;
+                printf("Js copied? %d \n", cJ) ;
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                J = malloc (nvals * sizeof (GrB_Index)) ;
-
-               // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    I[i] = (GrB_Index)java_is[i];
-                    J[i] = (GrB_Index)java_js[i];
-                }
-
-                long res = GrB_Matrix_build_BOOL(A, I, J, elms, nvals, dup);
+                long res = GrB_Matrix_build_BOOL(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
                 (*env)->ReleaseBooleanArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-                free(I);
-                free(J);
                 return res;
               }
 
@@ -178,53 +148,40 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jboolean *elms;
-                jlong *java_is;
+                jboolean *elms = (*env)->GetBooleanArrayElements(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
 
-                GrB_Index *I = NULL;
-
-                elms = (*env)->GetBooleanArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-
-               // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    I[i] = (GrB_Index)java_is[i];
-                }
-
-                long res = GrB_Vector_build_BOOL(A, I, elms, nvals, dup);
+                long res = GrB_Vector_build_BOOL(A, java_is, elms, nvals, dup);
                 // JNI tell Java we're done
                 (*env)->ReleaseBooleanArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                free(I);
                 return res;
               }
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setMatrixElementByte
             (JNIEnv * env, jclass cls, jobject mat, jlong i, jlong j, jbyte value) {
-            GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
+                GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index I = (GrB_Index)i;
                 GrB_Index J = (GrB_Index)j;
-            return check_grb_error( GrB_Matrix_setElement_INT8(A, value, I, J) ) ;
+                return check_grb_error( GrB_Matrix_setElement_INT8(A, value, I, J) ) ;
             }
 
 
             JNIEXPORT jbyteArray JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_getMatrixElementByte
             (JNIEnv * env, jclass cls, jobject mat, jlong i, jlong j) {
-            int8_t x;
-            GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
+                int8_t x;
+                GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index I = (GrB_Index)i;
                 GrB_Index J = (GrB_Index)j;
-            GrB_Info info = GrB_Matrix_extractElement_INT8(&x, A, I, J);
-            jbyteArray output;
-            if (info == GrB_NO_VALUE) {
-            output = (*env)->NewByteArray(env, 0);
-            } else {
-            output = (*env)->NewByteArray(env, 1);
-            int8_t xs[] = {x};
-            (*env)->SetByteArrayRegion(env, output, 0, 1, xs);
-            }
-            return output;
+                GrB_Info info = GrB_Matrix_extractElement_INT8(&x, A, I, J);
+                jbyteArray output;
+                if (info == GrB_NO_VALUE) {
+                    output = (*env)->NewByteArray(env, 0);
+                } else {
+                    output = (*env)->NewByteArray(env, 1);
+                    int8_t xs[] = {x};
+                    (*env)->SetByteArrayRegion(env, output, 0, 1, xs);
+                }
+                return output;
             }
 
 
@@ -234,30 +191,17 @@ long check_grb_error(GrB_Info info);
                 GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index nvals;
                 GrB_Matrix_nvals(&nvals, A);
-                jbyte *elms;
-                jlong *java_is;
-                jlong *java_js;
 
-                GrB_Index *I = NULL;
-                GrB_Index *J = NULL;
-                elms = (*env)->GetByteArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                java_js = (*env)->GetLongArrayElements(env, js, NULL);
+                jbyte *elms = (*env)->GetByteArrayElements(env, vs, NULL);
+                GrB_Index * java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                GrB_Index * java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, NULL);
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                J = malloc (nvals * sizeof (GrB_Index)) ;
-                long res = check_grb_error(GrB_Matrix_extractTuples_INT8(I, J, elms, &nvals, A));
-                // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    java_is[i] = (long) I[i];
-                    java_js[i] = (long) J[i];
-                }
+                long res = check_grb_error(GrB_Matrix_extractTuples_INT8(java_is, java_js, elms, &nvals, A));
+
                 // JNI tell Java we're done
                 (*env)->ReleaseByteArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-                free(I);
-                free(J);
                 return res;
               }
 
@@ -266,58 +210,41 @@ long check_grb_error(GrB_Info info);
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index nvals;
                 GrB_Vector_nvals(&nvals, A);
-                jbyte *elms;
-                jlong *java_is;
 
-                GrB_Index *I = NULL;
-                elms = (*env)->GetByteArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                jbyte *elms = (*env)->GetByteArrayElements(env, vs, NULL);
+                GrB_Index *java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                long res = check_grb_error(GrB_Vector_extractTuples_INT8(I, elms, &nvals, A));
-                // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    java_is[i] = (long) I[i];
-                }
+                long res = check_grb_error(GrB_Vector_extractTuples_INT8(java_is, elms, &nvals, A));
+
                 // JNI tell Java we're done
                 (*env)->ReleaseByteArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                free(I);
                 return res;
               }
+
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_buildMatrixFromTuplesByte
               (JNIEnv * env, jclass cls, jobject mat, jlongArray is, jlongArray js, jbyteArray vs, jlong n, jobject dupOp) {
                 GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jbyte *elms;
-                jlong *java_is;
-                jlong *java_js;
+                bool cV;
+                bool cI;
+                bool cJ;
 
-                GrB_Index *I = NULL;
-                GrB_Index *J = NULL;
+                jbyte* elms = (*env)->GetByteArrayElements(env, vs, &cV);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, &cI);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, &cJ);
 
-                elms = (*env)->GetByteArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                java_js = (*env)->GetLongArrayElements(env, js, NULL);
+                printf("Values copied? %d \n", cV) ;
+                printf("Is copied? %d \n", cI) ;
+                printf("Js copied? %d \n", cJ) ;
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                J = malloc (nvals * sizeof (GrB_Index)) ;
-
-               // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    I[i] = (GrB_Index)java_is[i];
-                    J[i] = (GrB_Index)java_js[i];
-                }
-
-                long res = GrB_Matrix_build_INT8(A, I, J, elms, nvals, dup);
+                long res = GrB_Matrix_build_INT8(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
                 (*env)->ReleaseByteArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-                free(I);
-                free(J);
                 return res;
               }
 
@@ -327,53 +254,40 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jbyte *elms;
-                jlong *java_is;
+                jbyte *elms = (*env)->GetByteArrayElements(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
 
-                GrB_Index *I = NULL;
-
-                elms = (*env)->GetByteArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-
-               // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    I[i] = (GrB_Index)java_is[i];
-                }
-
-                long res = GrB_Vector_build_INT8(A, I, elms, nvals, dup);
+                long res = GrB_Vector_build_INT8(A, java_is, elms, nvals, dup);
                 // JNI tell Java we're done
                 (*env)->ReleaseByteArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                free(I);
                 return res;
               }
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setMatrixElementShort
             (JNIEnv * env, jclass cls, jobject mat, jlong i, jlong j, jshort value) {
-            GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
+                GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index I = (GrB_Index)i;
                 GrB_Index J = (GrB_Index)j;
-            return check_grb_error( GrB_Matrix_setElement_INT16(A, value, I, J) ) ;
+                return check_grb_error( GrB_Matrix_setElement_INT16(A, value, I, J) ) ;
             }
 
 
             JNIEXPORT jshortArray JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_getMatrixElementShort
             (JNIEnv * env, jclass cls, jobject mat, jlong i, jlong j) {
-            short x;
-            GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
+                short x;
+                GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index I = (GrB_Index)i;
                 GrB_Index J = (GrB_Index)j;
-            GrB_Info info = GrB_Matrix_extractElement_INT16(&x, A, I, J);
-            jshortArray output;
-            if (info == GrB_NO_VALUE) {
-            output = (*env)->NewShortArray(env, 0);
-            } else {
-            output = (*env)->NewShortArray(env, 1);
-            short xs[] = {x};
-            (*env)->SetShortArrayRegion(env, output, 0, 1, xs);
-            }
-            return output;
+                GrB_Info info = GrB_Matrix_extractElement_INT16(&x, A, I, J);
+                jshortArray output;
+                if (info == GrB_NO_VALUE) {
+                    output = (*env)->NewShortArray(env, 0);
+                } else {
+                    output = (*env)->NewShortArray(env, 1);
+                    short xs[] = {x};
+                    (*env)->SetShortArrayRegion(env, output, 0, 1, xs);
+                }
+                return output;
             }
 
 
@@ -383,30 +297,17 @@ long check_grb_error(GrB_Info info);
                 GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index nvals;
                 GrB_Matrix_nvals(&nvals, A);
-                jshort *elms;
-                jlong *java_is;
-                jlong *java_js;
 
-                GrB_Index *I = NULL;
-                GrB_Index *J = NULL;
-                elms = (*env)->GetShortArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                java_js = (*env)->GetLongArrayElements(env, js, NULL);
+                jshort *elms = (*env)->GetShortArrayElements(env, vs, NULL);
+                GrB_Index * java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                GrB_Index * java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, NULL);
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                J = malloc (nvals * sizeof (GrB_Index)) ;
-                long res = check_grb_error(GrB_Matrix_extractTuples_INT16(I, J, elms, &nvals, A));
-                // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    java_is[i] = (long) I[i];
-                    java_js[i] = (long) J[i];
-                }
+                long res = check_grb_error(GrB_Matrix_extractTuples_INT16(java_is, java_js, elms, &nvals, A));
+
                 // JNI tell Java we're done
                 (*env)->ReleaseShortArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-                free(I);
-                free(J);
                 return res;
               }
 
@@ -415,58 +316,41 @@ long check_grb_error(GrB_Info info);
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index nvals;
                 GrB_Vector_nvals(&nvals, A);
-                jshort *elms;
-                jlong *java_is;
 
-                GrB_Index *I = NULL;
-                elms = (*env)->GetShortArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                jshort *elms = (*env)->GetShortArrayElements(env, vs, NULL);
+                GrB_Index *java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                long res = check_grb_error(GrB_Vector_extractTuples_INT16(I, elms, &nvals, A));
-                // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    java_is[i] = (long) I[i];
-                }
+                long res = check_grb_error(GrB_Vector_extractTuples_INT16(java_is, elms, &nvals, A));
+
                 // JNI tell Java we're done
                 (*env)->ReleaseShortArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                free(I);
                 return res;
               }
+
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_buildMatrixFromTuplesShort
               (JNIEnv * env, jclass cls, jobject mat, jlongArray is, jlongArray js, jshortArray vs, jlong n, jobject dupOp) {
                 GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jshort *elms;
-                jlong *java_is;
-                jlong *java_js;
+                bool cV;
+                bool cI;
+                bool cJ;
 
-                GrB_Index *I = NULL;
-                GrB_Index *J = NULL;
+                jshort* elms = (*env)->GetShortArrayElements(env, vs, &cV);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, &cI);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, &cJ);
 
-                elms = (*env)->GetShortArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                java_js = (*env)->GetLongArrayElements(env, js, NULL);
+                printf("Values copied? %d \n", cV) ;
+                printf("Is copied? %d \n", cI) ;
+                printf("Js copied? %d \n", cJ) ;
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                J = malloc (nvals * sizeof (GrB_Index)) ;
-
-               // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    I[i] = (GrB_Index)java_is[i];
-                    J[i] = (GrB_Index)java_js[i];
-                }
-
-                long res = GrB_Matrix_build_INT16(A, I, J, elms, nvals, dup);
+                long res = GrB_Matrix_build_INT16(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
                 (*env)->ReleaseShortArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-                free(I);
-                free(J);
                 return res;
               }
 
@@ -476,53 +360,40 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jshort *elms;
-                jlong *java_is;
+                jshort *elms = (*env)->GetShortArrayElements(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
 
-                GrB_Index *I = NULL;
-
-                elms = (*env)->GetShortArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-
-               // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    I[i] = (GrB_Index)java_is[i];
-                }
-
-                long res = GrB_Vector_build_INT16(A, I, elms, nvals, dup);
+                long res = GrB_Vector_build_INT16(A, java_is, elms, nvals, dup);
                 // JNI tell Java we're done
                 (*env)->ReleaseShortArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                free(I);
                 return res;
               }
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setMatrixElementInt
             (JNIEnv * env, jclass cls, jobject mat, jlong i, jlong j, jint value) {
-            GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
+                GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index I = (GrB_Index)i;
                 GrB_Index J = (GrB_Index)j;
-            return check_grb_error( GrB_Matrix_setElement_INT32(A, value, I, J) ) ;
+                return check_grb_error( GrB_Matrix_setElement_INT32(A, value, I, J) ) ;
             }
 
 
             JNIEXPORT jintArray JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_getMatrixElementInt
             (JNIEnv * env, jclass cls, jobject mat, jlong i, jlong j) {
-            int x;
-            GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
+                int x;
+                GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index I = (GrB_Index)i;
                 GrB_Index J = (GrB_Index)j;
-            GrB_Info info = GrB_Matrix_extractElement_INT32(&x, A, I, J);
-            jintArray output;
-            if (info == GrB_NO_VALUE) {
-            output = (*env)->NewIntArray(env, 0);
-            } else {
-            output = (*env)->NewIntArray(env, 1);
-            int xs[] = {x};
-            (*env)->SetIntArrayRegion(env, output, 0, 1, xs);
-            }
-            return output;
+                GrB_Info info = GrB_Matrix_extractElement_INT32(&x, A, I, J);
+                jintArray output;
+                if (info == GrB_NO_VALUE) {
+                    output = (*env)->NewIntArray(env, 0);
+                } else {
+                    output = (*env)->NewIntArray(env, 1);
+                    int xs[] = {x};
+                    (*env)->SetIntArrayRegion(env, output, 0, 1, xs);
+                }
+                return output;
             }
 
 
@@ -532,30 +403,17 @@ long check_grb_error(GrB_Info info);
                 GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index nvals;
                 GrB_Matrix_nvals(&nvals, A);
-                jint *elms;
-                jlong *java_is;
-                jlong *java_js;
 
-                GrB_Index *I = NULL;
-                GrB_Index *J = NULL;
-                elms = (*env)->GetIntArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                java_js = (*env)->GetLongArrayElements(env, js, NULL);
+                jint *elms = (*env)->GetIntArrayElements(env, vs, NULL);
+                GrB_Index * java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                GrB_Index * java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, NULL);
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                J = malloc (nvals * sizeof (GrB_Index)) ;
-                long res = check_grb_error(GrB_Matrix_extractTuples_INT32(I, J, elms, &nvals, A));
-                // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    java_is[i] = (long) I[i];
-                    java_js[i] = (long) J[i];
-                }
+                long res = check_grb_error(GrB_Matrix_extractTuples_INT32(java_is, java_js, elms, &nvals, A));
+
                 // JNI tell Java we're done
                 (*env)->ReleaseIntArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-                free(I);
-                free(J);
                 return res;
               }
 
@@ -564,58 +422,41 @@ long check_grb_error(GrB_Info info);
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index nvals;
                 GrB_Vector_nvals(&nvals, A);
-                jint *elms;
-                jlong *java_is;
 
-                GrB_Index *I = NULL;
-                elms = (*env)->GetIntArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                jint *elms = (*env)->GetIntArrayElements(env, vs, NULL);
+                GrB_Index *java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                long res = check_grb_error(GrB_Vector_extractTuples_INT32(I, elms, &nvals, A));
-                // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    java_is[i] = (long) I[i];
-                }
+                long res = check_grb_error(GrB_Vector_extractTuples_INT32(java_is, elms, &nvals, A));
+
                 // JNI tell Java we're done
                 (*env)->ReleaseIntArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                free(I);
                 return res;
               }
+
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_buildMatrixFromTuplesInt
               (JNIEnv * env, jclass cls, jobject mat, jlongArray is, jlongArray js, jintArray vs, jlong n, jobject dupOp) {
                 GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jint *elms;
-                jlong *java_is;
-                jlong *java_js;
+                bool cV;
+                bool cI;
+                bool cJ;
 
-                GrB_Index *I = NULL;
-                GrB_Index *J = NULL;
+                jint* elms = (*env)->GetIntArrayElements(env, vs, &cV);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, &cI);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, &cJ);
 
-                elms = (*env)->GetIntArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                java_js = (*env)->GetLongArrayElements(env, js, NULL);
+                printf("Values copied? %d \n", cV) ;
+                printf("Is copied? %d \n", cI) ;
+                printf("Js copied? %d \n", cJ) ;
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                J = malloc (nvals * sizeof (GrB_Index)) ;
-
-               // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    I[i] = (GrB_Index)java_is[i];
-                    J[i] = (GrB_Index)java_js[i];
-                }
-
-                long res = GrB_Matrix_build_INT32(A, I, J, elms, nvals, dup);
+                long res = GrB_Matrix_build_INT32(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
                 (*env)->ReleaseIntArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-                free(I);
-                free(J);
                 return res;
               }
 
@@ -625,53 +466,40 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jint *elms;
-                jlong *java_is;
+                jint *elms = (*env)->GetIntArrayElements(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
 
-                GrB_Index *I = NULL;
-
-                elms = (*env)->GetIntArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-
-               // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    I[i] = (GrB_Index)java_is[i];
-                }
-
-                long res = GrB_Vector_build_INT32(A, I, elms, nvals, dup);
+                long res = GrB_Vector_build_INT32(A, java_is, elms, nvals, dup);
                 // JNI tell Java we're done
                 (*env)->ReleaseIntArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                free(I);
                 return res;
               }
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setMatrixElementLong
             (JNIEnv * env, jclass cls, jobject mat, jlong i, jlong j, jlong value) {
-            GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
+                GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index I = (GrB_Index)i;
                 GrB_Index J = (GrB_Index)j;
-            return check_grb_error( GrB_Matrix_setElement_INT64(A, value, I, J) ) ;
+                return check_grb_error( GrB_Matrix_setElement_INT64(A, value, I, J) ) ;
             }
 
 
             JNIEXPORT jlongArray JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_getMatrixElementLong
             (JNIEnv * env, jclass cls, jobject mat, jlong i, jlong j) {
-            long x;
-            GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
+                long x;
+                GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index I = (GrB_Index)i;
                 GrB_Index J = (GrB_Index)j;
-            GrB_Info info = GrB_Matrix_extractElement_INT64(&x, A, I, J);
-            jlongArray output;
-            if (info == GrB_NO_VALUE) {
-            output = (*env)->NewLongArray(env, 0);
-            } else {
-            output = (*env)->NewLongArray(env, 1);
-            long xs[] = {x};
-            (*env)->SetLongArrayRegion(env, output, 0, 1, xs);
-            }
-            return output;
+                GrB_Info info = GrB_Matrix_extractElement_INT64(&x, A, I, J);
+                jlongArray output;
+                if (info == GrB_NO_VALUE) {
+                    output = (*env)->NewLongArray(env, 0);
+                } else {
+                    output = (*env)->NewLongArray(env, 1);
+                    long xs[] = {x};
+                    (*env)->SetLongArrayRegion(env, output, 0, 1, xs);
+                }
+                return output;
             }
 
 
@@ -681,30 +509,17 @@ long check_grb_error(GrB_Info info);
                 GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index nvals;
                 GrB_Matrix_nvals(&nvals, A);
-                jlong *elms;
-                jlong *java_is;
-                jlong *java_js;
 
-                GrB_Index *I = NULL;
-                GrB_Index *J = NULL;
-                elms = (*env)->GetLongArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                java_js = (*env)->GetLongArrayElements(env, js, NULL);
+                jlong *elms = (*env)->GetLongArrayElements(env, vs, NULL);
+                GrB_Index * java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                GrB_Index * java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, NULL);
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                J = malloc (nvals * sizeof (GrB_Index)) ;
-                long res = check_grb_error(GrB_Matrix_extractTuples_INT64(I, J, elms, &nvals, A));
-                // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    java_is[i] = (long) I[i];
-                    java_js[i] = (long) J[i];
-                }
+                long res = check_grb_error(GrB_Matrix_extractTuples_INT64(java_is, java_js, elms, &nvals, A));
+
                 // JNI tell Java we're done
                 (*env)->ReleaseLongArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-                free(I);
-                free(J);
                 return res;
               }
 
@@ -713,58 +528,41 @@ long check_grb_error(GrB_Info info);
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index nvals;
                 GrB_Vector_nvals(&nvals, A);
-                jlong *elms;
-                jlong *java_is;
 
-                GrB_Index *I = NULL;
-                elms = (*env)->GetLongArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                jlong *elms = (*env)->GetLongArrayElements(env, vs, NULL);
+                GrB_Index *java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                long res = check_grb_error(GrB_Vector_extractTuples_INT64(I, elms, &nvals, A));
-                // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    java_is[i] = (long) I[i];
-                }
+                long res = check_grb_error(GrB_Vector_extractTuples_INT64(java_is, elms, &nvals, A));
+
                 // JNI tell Java we're done
                 (*env)->ReleaseLongArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                free(I);
                 return res;
               }
+
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_buildMatrixFromTuplesLong
               (JNIEnv * env, jclass cls, jobject mat, jlongArray is, jlongArray js, jlongArray vs, jlong n, jobject dupOp) {
                 GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jlong *elms;
-                jlong *java_is;
-                jlong *java_js;
+                bool cV;
+                bool cI;
+                bool cJ;
 
-                GrB_Index *I = NULL;
-                GrB_Index *J = NULL;
+                jlong* elms = (*env)->GetLongArrayElements(env, vs, &cV);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, &cI);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, &cJ);
 
-                elms = (*env)->GetLongArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                java_js = (*env)->GetLongArrayElements(env, js, NULL);
+                printf("Values copied? %d \n", cV) ;
+                printf("Is copied? %d \n", cI) ;
+                printf("Js copied? %d \n", cJ) ;
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                J = malloc (nvals * sizeof (GrB_Index)) ;
-
-               // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    I[i] = (GrB_Index)java_is[i];
-                    J[i] = (GrB_Index)java_js[i];
-                }
-
-                long res = GrB_Matrix_build_INT64(A, I, J, elms, nvals, dup);
+                long res = GrB_Matrix_build_INT64(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
                 (*env)->ReleaseLongArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-                free(I);
-                free(J);
                 return res;
               }
 
@@ -774,53 +572,40 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jlong *elms;
-                jlong *java_is;
+                jlong *elms = (*env)->GetLongArrayElements(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
 
-                GrB_Index *I = NULL;
-
-                elms = (*env)->GetLongArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-
-               // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    I[i] = (GrB_Index)java_is[i];
-                }
-
-                long res = GrB_Vector_build_INT64(A, I, elms, nvals, dup);
+                long res = GrB_Vector_build_INT64(A, java_is, elms, nvals, dup);
                 // JNI tell Java we're done
                 (*env)->ReleaseLongArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                free(I);
                 return res;
               }
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setMatrixElementFloat
             (JNIEnv * env, jclass cls, jobject mat, jlong i, jlong j, jfloat value) {
-            GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
+                GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index I = (GrB_Index)i;
                 GrB_Index J = (GrB_Index)j;
-            return check_grb_error( GrB_Matrix_setElement_FP32(A, value, I, J) ) ;
+                return check_grb_error( GrB_Matrix_setElement_FP32(A, value, I, J) ) ;
             }
 
 
             JNIEXPORT jfloatArray JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_getMatrixElementFloat
             (JNIEnv * env, jclass cls, jobject mat, jlong i, jlong j) {
-            float x;
-            GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
+                float x;
+                GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index I = (GrB_Index)i;
                 GrB_Index J = (GrB_Index)j;
-            GrB_Info info = GrB_Matrix_extractElement_FP32(&x, A, I, J);
-            jfloatArray output;
-            if (info == GrB_NO_VALUE) {
-            output = (*env)->NewFloatArray(env, 0);
-            } else {
-            output = (*env)->NewFloatArray(env, 1);
-            float xs[] = {x};
-            (*env)->SetFloatArrayRegion(env, output, 0, 1, xs);
-            }
-            return output;
+                GrB_Info info = GrB_Matrix_extractElement_FP32(&x, A, I, J);
+                jfloatArray output;
+                if (info == GrB_NO_VALUE) {
+                    output = (*env)->NewFloatArray(env, 0);
+                } else {
+                    output = (*env)->NewFloatArray(env, 1);
+                    float xs[] = {x};
+                    (*env)->SetFloatArrayRegion(env, output, 0, 1, xs);
+                }
+                return output;
             }
 
 
@@ -830,30 +615,17 @@ long check_grb_error(GrB_Info info);
                 GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index nvals;
                 GrB_Matrix_nvals(&nvals, A);
-                jfloat *elms;
-                jlong *java_is;
-                jlong *java_js;
 
-                GrB_Index *I = NULL;
-                GrB_Index *J = NULL;
-                elms = (*env)->GetFloatArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                java_js = (*env)->GetLongArrayElements(env, js, NULL);
+                jfloat *elms = (*env)->GetFloatArrayElements(env, vs, NULL);
+                GrB_Index * java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                GrB_Index * java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, NULL);
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                J = malloc (nvals * sizeof (GrB_Index)) ;
-                long res = check_grb_error(GrB_Matrix_extractTuples_FP32(I, J, elms, &nvals, A));
-                // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    java_is[i] = (long) I[i];
-                    java_js[i] = (long) J[i];
-                }
+                long res = check_grb_error(GrB_Matrix_extractTuples_FP32(java_is, java_js, elms, &nvals, A));
+
                 // JNI tell Java we're done
                 (*env)->ReleaseFloatArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-                free(I);
-                free(J);
                 return res;
               }
 
@@ -862,58 +634,41 @@ long check_grb_error(GrB_Info info);
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index nvals;
                 GrB_Vector_nvals(&nvals, A);
-                jfloat *elms;
-                jlong *java_is;
 
-                GrB_Index *I = NULL;
-                elms = (*env)->GetFloatArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                jfloat *elms = (*env)->GetFloatArrayElements(env, vs, NULL);
+                GrB_Index *java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                long res = check_grb_error(GrB_Vector_extractTuples_FP32(I, elms, &nvals, A));
-                // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    java_is[i] = (long) I[i];
-                }
+                long res = check_grb_error(GrB_Vector_extractTuples_FP32(java_is, elms, &nvals, A));
+
                 // JNI tell Java we're done
                 (*env)->ReleaseFloatArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                free(I);
                 return res;
               }
+
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_buildMatrixFromTuplesFloat
               (JNIEnv * env, jclass cls, jobject mat, jlongArray is, jlongArray js, jfloatArray vs, jlong n, jobject dupOp) {
                 GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jfloat *elms;
-                jlong *java_is;
-                jlong *java_js;
+                bool cV;
+                bool cI;
+                bool cJ;
 
-                GrB_Index *I = NULL;
-                GrB_Index *J = NULL;
+                jfloat* elms = (*env)->GetFloatArrayElements(env, vs, &cV);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, &cI);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, &cJ);
 
-                elms = (*env)->GetFloatArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                java_js = (*env)->GetLongArrayElements(env, js, NULL);
+                printf("Values copied? %d \n", cV) ;
+                printf("Is copied? %d \n", cI) ;
+                printf("Js copied? %d \n", cJ) ;
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                J = malloc (nvals * sizeof (GrB_Index)) ;
-
-               // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    I[i] = (GrB_Index)java_is[i];
-                    J[i] = (GrB_Index)java_js[i];
-                }
-
-                long res = GrB_Matrix_build_FP32(A, I, J, elms, nvals, dup);
+                long res = GrB_Matrix_build_FP32(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
                 (*env)->ReleaseFloatArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-                free(I);
-                free(J);
                 return res;
               }
 
@@ -923,53 +678,40 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jfloat *elms;
-                jlong *java_is;
+                jfloat *elms = (*env)->GetFloatArrayElements(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
 
-                GrB_Index *I = NULL;
-
-                elms = (*env)->GetFloatArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-
-               // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    I[i] = (GrB_Index)java_is[i];
-                }
-
-                long res = GrB_Vector_build_FP32(A, I, elms, nvals, dup);
+                long res = GrB_Vector_build_FP32(A, java_is, elms, nvals, dup);
                 // JNI tell Java we're done
                 (*env)->ReleaseFloatArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                free(I);
                 return res;
               }
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setMatrixElementDouble
             (JNIEnv * env, jclass cls, jobject mat, jlong i, jlong j, jdouble value) {
-            GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
+                GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index I = (GrB_Index)i;
                 GrB_Index J = (GrB_Index)j;
-            return check_grb_error( GrB_Matrix_setElement_FP64(A, value, I, J) ) ;
+                return check_grb_error( GrB_Matrix_setElement_FP64(A, value, I, J) ) ;
             }
 
 
             JNIEXPORT jdoubleArray JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_getMatrixElementDouble
             (JNIEnv * env, jclass cls, jobject mat, jlong i, jlong j) {
-            double x;
-            GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
+                double x;
+                GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index I = (GrB_Index)i;
                 GrB_Index J = (GrB_Index)j;
-            GrB_Info info = GrB_Matrix_extractElement_FP64(&x, A, I, J);
-            jdoubleArray output;
-            if (info == GrB_NO_VALUE) {
-            output = (*env)->NewDoubleArray(env, 0);
-            } else {
-            output = (*env)->NewDoubleArray(env, 1);
-            double xs[] = {x};
-            (*env)->SetDoubleArrayRegion(env, output, 0, 1, xs);
-            }
-            return output;
+                GrB_Info info = GrB_Matrix_extractElement_FP64(&x, A, I, J);
+                jdoubleArray output;
+                if (info == GrB_NO_VALUE) {
+                    output = (*env)->NewDoubleArray(env, 0);
+                } else {
+                    output = (*env)->NewDoubleArray(env, 1);
+                    double xs[] = {x};
+                    (*env)->SetDoubleArrayRegion(env, output, 0, 1, xs);
+                }
+                return output;
             }
 
 
@@ -979,30 +721,17 @@ long check_grb_error(GrB_Info info);
                 GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index nvals;
                 GrB_Matrix_nvals(&nvals, A);
-                jdouble *elms;
-                jlong *java_is;
-                jlong *java_js;
 
-                GrB_Index *I = NULL;
-                GrB_Index *J = NULL;
-                elms = (*env)->GetDoubleArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                java_js = (*env)->GetLongArrayElements(env, js, NULL);
+                jdouble *elms = (*env)->GetDoubleArrayElements(env, vs, NULL);
+                GrB_Index * java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                GrB_Index * java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, NULL);
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                J = malloc (nvals * sizeof (GrB_Index)) ;
-                long res = check_grb_error(GrB_Matrix_extractTuples_FP64(I, J, elms, &nvals, A));
-                // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    java_is[i] = (long) I[i];
-                    java_js[i] = (long) J[i];
-                }
+                long res = check_grb_error(GrB_Matrix_extractTuples_FP64(java_is, java_js, elms, &nvals, A));
+
                 // JNI tell Java we're done
                 (*env)->ReleaseDoubleArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-                free(I);
-                free(J);
                 return res;
               }
 
@@ -1011,58 +740,41 @@ long check_grb_error(GrB_Info info);
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_Index nvals;
                 GrB_Vector_nvals(&nvals, A);
-                jdouble *elms;
-                jlong *java_is;
 
-                GrB_Index *I = NULL;
-                elms = (*env)->GetDoubleArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                jdouble *elms = (*env)->GetDoubleArrayElements(env, vs, NULL);
+                GrB_Index *java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                long res = check_grb_error(GrB_Vector_extractTuples_FP64(I, elms, &nvals, A));
-                // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    java_is[i] = (long) I[i];
-                }
+                long res = check_grb_error(GrB_Vector_extractTuples_FP64(java_is, elms, &nvals, A));
+
                 // JNI tell Java we're done
                 (*env)->ReleaseDoubleArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                free(I);
                 return res;
               }
+
             JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_buildMatrixFromTuplesDouble
               (JNIEnv * env, jclass cls, jobject mat, jlongArray is, jlongArray js, jdoubleArray vs, jlong n, jobject dupOp) {
                 GrB_Matrix A = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jdouble *elms;
-                jlong *java_is;
-                jlong *java_js;
+                bool cV;
+                bool cI;
+                bool cJ;
 
-                GrB_Index *I = NULL;
-                GrB_Index *J = NULL;
+                jdouble* elms = (*env)->GetDoubleArrayElements(env, vs, &cV);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, &cI);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, &cJ);
 
-                elms = (*env)->GetDoubleArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-                java_js = (*env)->GetLongArrayElements(env, js, NULL);
+                printf("Values copied? %d \n", cV) ;
+                printf("Is copied? %d \n", cI) ;
+                printf("Js copied? %d \n", cJ) ;
 
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-                J = malloc (nvals * sizeof (GrB_Index)) ;
-
-               // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    I[i] = (GrB_Index)java_is[i];
-                    J[i] = (GrB_Index)java_js[i];
-                }
-
-                long res = GrB_Matrix_build_FP64(A, I, J, elms, nvals, dup);
+                long res = GrB_Matrix_build_FP64(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
                 (*env)->ReleaseDoubleArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
                 (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-                free(I);
-                free(J);
                 return res;
               }
 
@@ -1072,33 +784,20 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                jdouble *elms;
-                jlong *java_is;
+                jdouble *elms = (*env)->GetDoubleArrayElements(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
 
-                GrB_Index *I = NULL;
-
-                elms = (*env)->GetDoubleArrayElements(env, vs, NULL);
-                java_is = (*env)->GetLongArrayElements(env, is, NULL);
-
-                I = malloc (nvals * sizeof (GrB_Index)) ;
-
-               // just copy :(
-                for (int i = 0; i < nvals; i++) {
-                    I[i] = (GrB_Index)java_is[i];
-                }
-
-                long res = GrB_Vector_build_FP64(A, I, elms, nvals, dup);
+                long res = GrB_Vector_build_FP64(A, java_is, elms, nvals, dup);
                 // JNI tell Java we're done
                 (*env)->ReleaseDoubleArrayElements(env, vs, elms, 0);
                 (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                free(I);
                 return res;
               }
 
                 JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setVectorElementBoolean
                 (JNIEnv * env, jclass cls, jobject mat, jlong i, jboolean value) {
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
-                GrB_Index I = (GrB_Index)i;
+                GrB_Index I = (GrB_Index) i;
                 return check_grb_error( GrB_Vector_setElement_BOOL(A, value, I) ) ;
                 }
 
@@ -1107,15 +806,15 @@ long check_grb_error(GrB_Info info);
                 (JNIEnv * env, jclass cls, jobject mat, jlong i) {
                 bool x;
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
-                GrB_Index I = (GrB_Index)i;
+                GrB_Index I = (GrB_Index) i;
                 GrB_Info info = GrB_Vector_extractElement_BOOL(&x, A, I);
                 jbooleanArray output;
                 if (info == GrB_NO_VALUE) {
-                output = (*env)->NewBooleanArray(env, 0);
+                    output = (*env)->NewBooleanArray(env, 0);
                 } else {
-                output = (*env)->NewBooleanArray(env, 1);
-                bool xs[] = {x};
-                (*env)->SetBooleanArrayRegion(env, output, 0, 1, xs);
+                    output = (*env)->NewBooleanArray(env, 1);
+                    bool xs[] = {x};
+                    (*env)->SetBooleanArrayRegion(env, output, 0, 1, xs);
                 }
                 return output;
                 }
@@ -1123,7 +822,7 @@ long check_grb_error(GrB_Info info);
                 JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setVectorElementByte
                 (JNIEnv * env, jclass cls, jobject mat, jlong i, jbyte value) {
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
-                GrB_Index I = (GrB_Index)i;
+                GrB_Index I = (GrB_Index) i;
                 return check_grb_error( GrB_Vector_setElement_INT8(A, value, I) ) ;
                 }
 
@@ -1132,15 +831,15 @@ long check_grb_error(GrB_Info info);
                 (JNIEnv * env, jclass cls, jobject mat, jlong i) {
                 int8_t x;
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
-                GrB_Index I = (GrB_Index)i;
+                GrB_Index I = (GrB_Index) i;
                 GrB_Info info = GrB_Vector_extractElement_INT8(&x, A, I);
                 jbyteArray output;
                 if (info == GrB_NO_VALUE) {
-                output = (*env)->NewByteArray(env, 0);
+                    output = (*env)->NewByteArray(env, 0);
                 } else {
-                output = (*env)->NewByteArray(env, 1);
-                int8_t xs[] = {x};
-                (*env)->SetByteArrayRegion(env, output, 0, 1, xs);
+                    output = (*env)->NewByteArray(env, 1);
+                    int8_t xs[] = {x};
+                    (*env)->SetByteArrayRegion(env, output, 0, 1, xs);
                 }
                 return output;
                 }
@@ -1148,7 +847,7 @@ long check_grb_error(GrB_Info info);
                 JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setVectorElementShort
                 (JNIEnv * env, jclass cls, jobject mat, jlong i, jshort value) {
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
-                GrB_Index I = (GrB_Index)i;
+                GrB_Index I = (GrB_Index) i;
                 return check_grb_error( GrB_Vector_setElement_INT16(A, value, I) ) ;
                 }
 
@@ -1157,15 +856,15 @@ long check_grb_error(GrB_Info info);
                 (JNIEnv * env, jclass cls, jobject mat, jlong i) {
                 short x;
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
-                GrB_Index I = (GrB_Index)i;
+                GrB_Index I = (GrB_Index) i;
                 GrB_Info info = GrB_Vector_extractElement_INT16(&x, A, I);
                 jshortArray output;
                 if (info == GrB_NO_VALUE) {
-                output = (*env)->NewShortArray(env, 0);
+                    output = (*env)->NewShortArray(env, 0);
                 } else {
-                output = (*env)->NewShortArray(env, 1);
-                short xs[] = {x};
-                (*env)->SetShortArrayRegion(env, output, 0, 1, xs);
+                    output = (*env)->NewShortArray(env, 1);
+                    short xs[] = {x};
+                    (*env)->SetShortArrayRegion(env, output, 0, 1, xs);
                 }
                 return output;
                 }
@@ -1173,7 +872,7 @@ long check_grb_error(GrB_Info info);
                 JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setVectorElementInt
                 (JNIEnv * env, jclass cls, jobject mat, jlong i, jint value) {
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
-                GrB_Index I = (GrB_Index)i;
+                GrB_Index I = (GrB_Index) i;
                 return check_grb_error( GrB_Vector_setElement_INT32(A, value, I) ) ;
                 }
 
@@ -1182,15 +881,15 @@ long check_grb_error(GrB_Info info);
                 (JNIEnv * env, jclass cls, jobject mat, jlong i) {
                 int x;
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
-                GrB_Index I = (GrB_Index)i;
+                GrB_Index I = (GrB_Index) i;
                 GrB_Info info = GrB_Vector_extractElement_INT32(&x, A, I);
                 jintArray output;
                 if (info == GrB_NO_VALUE) {
-                output = (*env)->NewIntArray(env, 0);
+                    output = (*env)->NewIntArray(env, 0);
                 } else {
-                output = (*env)->NewIntArray(env, 1);
-                int xs[] = {x};
-                (*env)->SetIntArrayRegion(env, output, 0, 1, xs);
+                    output = (*env)->NewIntArray(env, 1);
+                    int xs[] = {x};
+                    (*env)->SetIntArrayRegion(env, output, 0, 1, xs);
                 }
                 return output;
                 }
@@ -1198,7 +897,7 @@ long check_grb_error(GrB_Info info);
                 JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setVectorElementLong
                 (JNIEnv * env, jclass cls, jobject mat, jlong i, jlong value) {
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
-                GrB_Index I = (GrB_Index)i;
+                GrB_Index I = (GrB_Index) i;
                 return check_grb_error( GrB_Vector_setElement_INT64(A, value, I) ) ;
                 }
 
@@ -1207,15 +906,15 @@ long check_grb_error(GrB_Info info);
                 (JNIEnv * env, jclass cls, jobject mat, jlong i) {
                 long x;
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
-                GrB_Index I = (GrB_Index)i;
+                GrB_Index I = (GrB_Index) i;
                 GrB_Info info = GrB_Vector_extractElement_INT64(&x, A, I);
                 jlongArray output;
                 if (info == GrB_NO_VALUE) {
-                output = (*env)->NewLongArray(env, 0);
+                    output = (*env)->NewLongArray(env, 0);
                 } else {
-                output = (*env)->NewLongArray(env, 1);
-                long xs[] = {x};
-                (*env)->SetLongArrayRegion(env, output, 0, 1, xs);
+                    output = (*env)->NewLongArray(env, 1);
+                    long xs[] = {x};
+                    (*env)->SetLongArrayRegion(env, output, 0, 1, xs);
                 }
                 return output;
                 }
@@ -1223,7 +922,7 @@ long check_grb_error(GrB_Info info);
                 JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setVectorElementFloat
                 (JNIEnv * env, jclass cls, jobject mat, jlong i, jfloat value) {
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
-                GrB_Index I = (GrB_Index)i;
+                GrB_Index I = (GrB_Index) i;
                 return check_grb_error( GrB_Vector_setElement_FP32(A, value, I) ) ;
                 }
 
@@ -1232,15 +931,15 @@ long check_grb_error(GrB_Info info);
                 (JNIEnv * env, jclass cls, jobject mat, jlong i) {
                 float x;
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
-                GrB_Index I = (GrB_Index)i;
+                GrB_Index I = (GrB_Index) i;
                 GrB_Info info = GrB_Vector_extractElement_FP32(&x, A, I);
                 jfloatArray output;
                 if (info == GrB_NO_VALUE) {
-                output = (*env)->NewFloatArray(env, 0);
+                    output = (*env)->NewFloatArray(env, 0);
                 } else {
-                output = (*env)->NewFloatArray(env, 1);
-                float xs[] = {x};
-                (*env)->SetFloatArrayRegion(env, output, 0, 1, xs);
+                    output = (*env)->NewFloatArray(env, 1);
+                    float xs[] = {x};
+                    (*env)->SetFloatArrayRegion(env, output, 0, 1, xs);
                 }
                 return output;
                 }
@@ -1248,7 +947,7 @@ long check_grb_error(GrB_Info info);
                 JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRAPHBLAS_setVectorElementDouble
                 (JNIEnv * env, jclass cls, jobject mat, jlong i, jdouble value) {
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
-                GrB_Index I = (GrB_Index)i;
+                GrB_Index I = (GrB_Index) i;
                 return check_grb_error( GrB_Vector_setElement_FP64(A, value, I) ) ;
                 }
 
@@ -1257,15 +956,15 @@ long check_grb_error(GrB_Info info);
                 (JNIEnv * env, jclass cls, jobject mat, jlong i) {
                 double x;
                 GrB_Vector A = (GrB_Vector) (*env)->GetDirectBufferAddress(env, mat);
-                GrB_Index I = (GrB_Index)i;
+                GrB_Index I = (GrB_Index) i;
                 GrB_Info info = GrB_Vector_extractElement_FP64(&x, A, I);
                 jdoubleArray output;
                 if (info == GrB_NO_VALUE) {
-                output = (*env)->NewDoubleArray(env, 0);
+                    output = (*env)->NewDoubleArray(env, 0);
                 } else {
-                output = (*env)->NewDoubleArray(env, 1);
-                double xs[] = {x};
-                (*env)->SetDoubleArrayRegion(env, output, 0, 1, xs);
+                    output = (*env)->NewDoubleArray(env, 1);
+                    double xs[] = {x};
+                    (*env)->SetDoubleArrayRegion(env, output, 0, 1, xs);
                 }
                 return output;
                 }

--- a/graphblas-java/src/main/c/unsafe_ops.c
+++ b/graphblas-java/src/main/c/unsafe_ops.c
@@ -220,6 +220,10 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSMAT_extract
         java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
         java_js = (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
+        if (java_is == NULL || java_js == NULL) {
+            return GrB_OUT_OF_MEMORY;
+        }
+
         long java_min = -9223372036854775808;
         I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
         J = java_js[0] != java_min ? (GrB_Index*) java_js : GrB_ALL;
@@ -252,10 +256,13 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSVEC_extract
         GrB_Vector first = (GrB_Vector) (*env)->GetDirectBufferAddress(env, u);
 
         jlong *java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
-        GrB_Index *I = NULL;
+
+        if (java_is == NULL) {
+            return GrB_OUT_OF_MEMORY;
+        }
 
         long java_min = -9223372036854775808;
-        I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
+        GrB_Index *I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
         // Optionals
         GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL ;
@@ -288,17 +295,16 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSMAT_assign
         GrB_Matrix out = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
         GrB_Matrix first = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, A);
 
-        jlong *java_is;
-        jlong *java_js;
-        GrB_Index *I = NULL;
-        GrB_Index *J = NULL;
+        jlong *java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+        jlong *java_js = (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
-        java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
-        java_js = (*env)->GetPrimitiveArrayCritical(env, js, NULL);
+        if (java_is == NULL || java_js == NULL) {
+            return GrB_OUT_OF_MEMORY;
+        }
 
         long java_min = -9223372036854775808;
-        I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
-        J = java_js[0] != java_min ? (GrB_Index*) java_js : GrB_ALL;
+        GrB_Index *I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
+        GrB_Index *J = java_js[0] != java_min ? (GrB_Index*) java_js : GrB_ALL;
 
         // Optionals
         GrB_Matrix m = mask != NULL ? (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mask) : NULL ;
@@ -326,12 +332,15 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSVEC_assign
         GrB_Vector out = (GrB_Vector) (*env)->GetDirectBufferAddress(env, vec);
         GrB_Vector first = (GrB_Vector) (*env)->GetDirectBufferAddress(env, u);
 
-        GrB_Index *I = NULL;
         jlong *java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+        if (java_is == NULL) {
+            return GrB_OUT_OF_MEMORY;
+        }
 
         long java_min = -9223372036854775808;
 
-        I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
+        GrB_Index *I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
         // Optionals
         GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL ;
@@ -365,17 +374,16 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSMAT_subAssign
         GrB_Matrix out = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mat);
         GrB_Matrix first = (GrB_Matrix) (*env)->GetDirectBufferAddress(env, A);
 
-        jlong *java_is;
-        jlong *java_js;
-        GrB_Index *I = NULL;
-        GrB_Index *J = NULL;
+        jlong *java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+        jlong *java_js = (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
-        java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
-        java_js = (*env)->GetPrimitiveArrayCritical(env, js, NULL);
+        if (java_is == NULL || java_js == NULL) {
+            return GrB_OUT_OF_MEMORY;
+        }
 
         long java_min = -9223372036854775808;
-        I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
-        J = java_js[0] != java_min ? (GrB_Index*) java_js : GrB_ALL;
+        GrB_Index *I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
+        GrB_Index *J = java_js[0] != java_min ? (GrB_Index*) java_js : GrB_ALL;
 
         // Optionals
         GrB_Matrix m = mask != NULL ? (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mask) : NULL ;
@@ -404,13 +412,14 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSVEC_subAssign
         GrB_Vector out = (GrB_Vector) (*env)->GetDirectBufferAddress(env, vec);
         GrB_Vector first = (GrB_Vector) (*env)->GetDirectBufferAddress(env, u);
 
-        jlong *java_is;
-        GrB_Index *I = NULL;
+        jlong *java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
-        java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+        if (java_is == NULL) {
+            return GrB_OUT_OF_MEMORY;
+        }
 
         long java_min = -9223372036854775808;
-        I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
+        GrB_Index *I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
         // Optionals
         GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL ;

--- a/graphblas-java/src/main/c/unsafe_ops.c
+++ b/graphblas-java/src/main/c/unsafe_ops.c
@@ -221,6 +221,13 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSMAT_extract
         java_js = (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
         if (java_is == NULL || java_js == NULL) {
+            if(java_is != NULL) {
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+            }
+
+            if(java_js != NULL) {
+                (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
+            }
             return GrB_OUT_OF_MEMORY;
         }
 
@@ -299,6 +306,14 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSMAT_assign
         jlong *java_js = (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
         if (java_is == NULL || java_js == NULL) {
+            if(java_is != NULL) {
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+            }
+
+            if(java_js != NULL) {
+                (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
+            }
+
             return GrB_OUT_OF_MEMORY;
         }
 
@@ -378,6 +393,14 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSMAT_subAssign
         jlong *java_js = (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
         if (java_is == NULL || java_js == NULL) {
+            if(java_is != NULL) {
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+            }
+
+            if(java_js != NULL) {
+                (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
+            }
+
             return GrB_OUT_OF_MEMORY;
         }
 

--- a/graphblas-java/src/main/c/unsafe_ops.c
+++ b/graphblas-java/src/main/c/unsafe_ops.c
@@ -217,41 +217,13 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSMAT_extract
         GrB_Index *I = NULL;
         GrB_Index *J = NULL;
 
-        java_is = (*env)->GetLongArrayElements(env, is, NULL);
-        java_js = (*env)->GetLongArrayElements(env, js, NULL);
-
-        GrB_Index sizei;
-        GrB_Index sizej;
-        if (grb_ni == GxB_RANGE) {
-            sizei = 2;
-        } else if (grb_ni == GxB_BACKWARDS || grb_ni == GxB_STRIDE){
-            sizei = 3;
-        } else {
-            sizei = grb_ni;
-        }
-
-        if (grb_nj == GxB_RANGE) {
-            sizej = 2;
-        } else if (grb_nj == GxB_BACKWARDS || grb_nj == GxB_STRIDE){
-            sizej = 3;
-        } else {
-            sizej = grb_nj;
-        }
+        java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+        java_js = (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
         long java_min = -9223372036854775808;
-        I = java_is[0] != java_min ? malloc (sizei * sizeof (GrB_Index)) : GrB_ALL;
-        J = java_js[0] != java_min ? malloc (sizej * sizeof (GrB_Index)) : GrB_ALL;
+        I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
+        J = java_js[0] != java_min ? (GrB_Index*) java_js : GrB_ALL;
 
-        if (I != GrB_ALL) {
-            for (int i = 0; i < sizei; i++) {
-                I[i] = (GrB_Index)java_is[i];
-            }
-        }
-        if (J != GrB_ALL) {
-            for (int i = 0; i < sizej; i++) {
-                J[i] = (GrB_Index)java_js[i];
-            }
-        }
 
         // Optionals
         GrB_Matrix m = mask != NULL ? (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mask) : NULL ;
@@ -260,14 +232,8 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSMAT_extract
 
         long res = check_grb_error(GrB_extract(out, m, acc, first, I, grb_ni, J, grb_nj, d));
 
-        (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-        (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-        if (I != GrB_ALL) {
-            free(I);
-        }
-        if (J != GrB_ALL) {
-            free(J);
-        }
+        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
 
        return res;
 
@@ -285,33 +251,11 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSVEC_extract
         GrB_Vector out = (GrB_Vector) (*env)->GetDirectBufferAddress(env, vec);
         GrB_Vector first = (GrB_Vector) (*env)->GetDirectBufferAddress(env, u);
 
-        jlong *java_is = (*env)->GetLongArrayElements(env, is, NULL);
+        jlong *java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
         GrB_Index *I = NULL;
 
-        GrB_Index sizei;
-
-        if (grb_ni == GxB_RANGE) {
-            sizei = 2;
-        } else if (grb_ni == GxB_BACKWARDS || grb_ni == GxB_STRIDE){
-            sizei = 3;
-        } else {
-            sizei = grb_ni;
-        }
-
         long java_min = -9223372036854775808;
-
-        if (java_is[0] == java_min) {
-            I = GrB_ALL;
-        }
-        else {
-            I = malloc (sizei * sizeof (GrB_Index));
-
-            for (int i = 0; i < sizei; i++) {
-                I[i] = (GrB_Index)java_is[i];
-            }
-
-            (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-        }
+        I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
         // Optionals
         GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL ;
@@ -320,9 +264,7 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSVEC_extract
 
         long res = check_grb_error(GrB_Vector_extract(out, m, acc, first, I, grb_ni, d));
 
-        if (I != GrB_ALL) {
-            free(I);
-        }
+       (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
 
        return res;
 
@@ -351,42 +293,12 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSMAT_assign
         GrB_Index *I = NULL;
         GrB_Index *J = NULL;
 
-        java_is = (*env)->GetLongArrayElements(env, is, NULL);
-        java_js = (*env)->GetLongArrayElements(env, js, NULL);
-
-        GrB_Index sizei;
-        GrB_Index sizej;
-
-        if (grb_ni == GxB_RANGE) {
-            sizei = 2;
-        } else if (grb_ni == GxB_BACKWARDS || grb_ni == GxB_STRIDE){
-            sizei = 3;
-        } else {
-            sizei = grb_ni;
-        }
-
-        if (grb_nj == GxB_RANGE) {
-            sizej = 2;
-        } else if (grb_nj == GxB_BACKWARDS || grb_nj == GxB_STRIDE){
-            sizej = 3;
-        } else {
-            sizej = grb_nj;
-        }
+        java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+        java_js = (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
         long java_min = -9223372036854775808;
-        I = java_is[0] != java_min ? malloc (sizei * sizeof (GrB_Index)) : GrB_ALL;
-        J = java_js[0] != java_min ? malloc (sizej * sizeof (GrB_Index)) : GrB_ALL;
-
-        if (I != GrB_ALL) {
-            for (int i = 0; i < sizei; i++) {
-                I[i] = (GrB_Index)java_is[i];
-            }
-        }
-        if (J != GrB_ALL) {
-            for (int i = 0; i < sizej; i++) {
-                J[i] = (GrB_Index)java_js[i];
-            }
-        }
+        I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
+        J = java_js[0] != java_min ? (GrB_Index*) java_js : GrB_ALL;
 
         // Optionals
         GrB_Matrix m = mask != NULL ? (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mask) : NULL ;
@@ -395,14 +307,8 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSMAT_assign
 
         long res = check_grb_error(GrB_assign(out, m, acc, first, I, grb_ni, J, grb_nj, d));
 
-        (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-        (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-        if (I != GrB_ALL) {
-            free(I);
-        }
-        if (J != GrB_ALL) {
-            free(J);
-        }
+        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
 
        return res;
 
@@ -421,32 +327,12 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSVEC_assign
         GrB_Vector first = (GrB_Vector) (*env)->GetDirectBufferAddress(env, u);
 
         GrB_Index *I = NULL;
-        jlong *java_is = (*env)->GetLongArrayElements(env, is, NULL);
-
+        jlong *java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
         long java_min = -9223372036854775808;
 
-        if (java_is[0] == java_min) {
-            I = GrB_ALL;
-        }
-        else {
-            GrB_Index sizei;
-            if (grb_ni == GxB_RANGE) {
-                sizei = 2;
-            } else if (grb_ni == GxB_BACKWARDS || grb_ni == GxB_STRIDE){
-                sizei = 3;
-            } else {
-                sizei = grb_ni;
-            }
+        I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
-            I = malloc (sizei * sizeof (GrB_Index)) ;
-
-            for (int i = 0; i < sizei; i++) {
-                I[i] = (GrB_Index)java_is[i];
-            }
-
-            (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-        }
         // Optionals
         GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL ;
         GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum) : NULL;
@@ -454,9 +340,7 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSVEC_assign
 
         long res = check_grb_error(GrB_assign(out, m, acc, first, I, grb_ni, d));
 
-        if(I != GrB_ALL) {
-            free(I);
-        }
+       (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
 
        return res;
 
@@ -486,41 +370,12 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSMAT_subAssign
         GrB_Index *I = NULL;
         GrB_Index *J = NULL;
 
-        java_is = (*env)->GetLongArrayElements(env, is, NULL);
-        java_js = (*env)->GetLongArrayElements(env, js, NULL);
-
-        GrB_Index sizei;
-        GrB_Index sizej;
-        if (grb_ni == GxB_RANGE) {
-            sizei = 2;
-        } else if (grb_ni == GxB_BACKWARDS || grb_ni == GxB_STRIDE){
-            sizei = 3;
-        } else {
-            sizei = grb_ni;
-        }
-
-        if (grb_nj == GxB_RANGE) {
-            sizej = 2;
-        } else if (grb_nj == GxB_BACKWARDS || grb_nj == GxB_STRIDE){
-            sizej = 3;
-        } else {
-            sizej = grb_nj;
-        }
+        java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+        java_js = (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
         long java_min = -9223372036854775808;
-        I = java_is[0] != java_min ? malloc (sizei * sizeof (GrB_Index)) : GrB_ALL;
-        J = java_js[0] != java_min ? malloc (sizej * sizeof (GrB_Index)) : GrB_ALL;
-
-        if (I != GrB_ALL) {
-            for (int i = 0; i < sizei; i++) {
-                I[i] = (GrB_Index)java_is[i];
-            }
-        }
-        if (J != GrB_ALL) {
-            for (int i = 0; i < sizej; i++) {
-                J[i] = (GrB_Index)java_js[i];
-            }
-        }
+        I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
+        J = java_js[0] != java_min ? (GrB_Index*) java_js : GrB_ALL;
 
         // Optionals
         GrB_Matrix m = mask != NULL ? (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mask) : NULL ;
@@ -529,14 +384,8 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSMAT_subAssign
 
         long res = check_grb_error(GxB_subassign(out, m, acc, first, I, grb_ni, J, grb_nj, d));
 
-        (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-        (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
-        if (I != GrB_ALL) {
-            free(I);
-        }
-        if (J != GrB_ALL) {
-            free(J);
-        }
+        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
 
        return res;
 
@@ -558,22 +407,10 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSVEC_subAssign
         jlong *java_is;
         GrB_Index *I = NULL;
 
-        java_is = (*env)->GetLongArrayElements(env, is, NULL);
+        java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
-        GrB_Index sizei;
-        if (grb_ni == GxB_RANGE) {
-            sizei = 2;
-        } else if (grb_ni == GxB_BACKWARDS || grb_ni == GxB_STRIDE){
-            sizei = 3;
-        } else {
-            sizei = grb_ni;
-        }
-
-        I = malloc (sizei * sizeof (GrB_Index)) ;
-
-        for (int i = 0; i < sizei; i++) {
-            I[i] = (GrB_Index)java_is[i];
-        }
+        long java_min = -9223372036854775808;
+        I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
         // Optionals
         GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL ;
@@ -582,8 +419,7 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSVEC_subAssign
 
         long res = check_grb_error(GxB_Vector_subassign(out, m, acc, first, I, grb_ni, d));
 
-        (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-        free(I);
+       (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
 
        return res;
   }

--- a/graphblas-java/src/main/c/unsafe_ops.c
+++ b/graphblas-java/src/main/c/unsafe_ops.c
@@ -432,7 +432,7 @@ JNIEXPORT jlong JNICALL Java_com_github_fabianmurariu_unsafe_GRBOPSMAT_select
         GxB_SelectOp grb_op = (GxB_SelectOp) (*env)->GetDirectBufferAddress(env, op);
 
         // Optionals
-        GrB_Vector m = mask != NULL ? (GrB_Vector) (*env)->GetDirectBufferAddress(env, mask) : NULL ;
+        GrB_Matrix m = mask != NULL ? (GrB_Matrix) (*env)->GetDirectBufferAddress(env, mask) : NULL ;
         GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum) : NULL;
         GrB_Descriptor d = desc != NULL ? (GrB_Descriptor) (*env)->GetDirectBufferAddress(env, desc) : NULL;
         GxB_Scalar grb_thunk = NULL;

--- a/graphblas-java/src/main/templates/c/unsafe_gen.c.ftl
+++ b/graphblas-java/src/main/templates/c/unsafe_gen.c.ftl
@@ -53,16 +53,16 @@ long check_grb_error(GrB_Info info);
                 GrB_Index nvals;
                 GrB_Matrix_nvals(&nvals, A);
 
-                j${prop.java_type} *elms = (*env)->Get${prop.java_type?cap_first}ArrayElements(env, vs, NULL);
-                GrB_Index * java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
-                GrB_Index * java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, NULL);
+                j${prop.java_type} *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index * java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+                GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 long res = check_grb_error(GrB_Matrix_extractTuples_${prop.grb_type}(java_is, java_js, elms, &nvals, A));
 
                 // JNI tell Java we're done
-                (*env)->Release${prop.java_type?cap_first}ArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
                 return res;
               }
 
@@ -72,14 +72,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index nvals;
                 GrB_Vector_nvals(&nvals, A);
 
-                j${prop.java_type} *elms = (*env)->Get${prop.java_type?cap_first}ArrayElements(env, vs, NULL);
-                GrB_Index *java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                j${prop.java_type} *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 long res = check_grb_error(GrB_Vector_extractTuples_${prop.grb_type}(java_is, elms, &nvals, A));
 
                 // JNI tell Java we're done
-                (*env)->Release${prop.java_type?cap_first}ArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
                 return res;
               }
 
@@ -93,9 +93,9 @@ long check_grb_error(GrB_Info info);
                 bool cI;
                 bool cJ;
 
-                j${prop.java_type}* elms = (*env)->Get${prop.java_type?cap_first}ArrayElements(env, vs, &cV);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, &cI);
-                GrB_Index* java_js = (GrB_Index*) (*env)->GetLongArrayElements(env, js, &cJ);
+                j${prop.java_type}* elms = (*env)->GetPrimitiveArrayCritical(env, vs, &cV);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, &cI);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, &cJ);
 
                 printf("Values copied? %d \n", cV) ;
                 printf("Is copied? %d \n", cI) ;
@@ -103,9 +103,9 @@ long check_grb_error(GrB_Info info);
 
                 long res = GrB_Matrix_build_${prop.grb_type}(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done
-                (*env)->Release${prop.java_type?cap_first}ArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                (*env)->ReleaseLongArrayElements(env, js, java_js, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
                 return res;
               }
 
@@ -115,13 +115,13 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                j${prop.java_type} *elms = (*env)->Get${prop.java_type?cap_first}ArrayElements(env, vs, NULL);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetLongArrayElements(env, is, NULL);
+                j${prop.java_type} *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 long res = GrB_Vector_build_${prop.grb_type}(A, java_is, elms, nvals, dup);
                 // JNI tell Java we're done
-                (*env)->Release${prop.java_type?cap_first}ArrayElements(env, vs, elms, 0);
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
                 return res;
               }
             </#list>
@@ -163,19 +163,14 @@ long check_grb_error(GrB_Info info);
 
                 GrB_Index* I = NULL;
                 GrB_Index grb_ni = (GrB_Index) ni;
-                jlong * java_is = (*env)->GetLongArrayElements(env, is, NULL);
+                jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 long java_min = -9223372036854775808;
 
                 if (java_is[0] == java_min) {
                     I = GrB_ALL;
                 }
                 else {
-                    I = malloc (grb_ni * sizeof (GrB_Index));
-
-                    // just copy :(
-                    for (int i = 0; i < grb_ni; i++) {
-                        I[i] = (GrB_Index)java_is[i];
-                    }
+                    I = (GrB_Index*) java_is;
                 }
 
                 // OPTIONAL STUFF
@@ -186,10 +181,7 @@ long check_grb_error(GrB_Info info);
 
                 long res = check_grb_error(GrB_Vector_assign_${prop.grb_type}(w, m, acc, value, I, grb_ni, d));
 
-                (*env)->ReleaseLongArrayElements(env, is, java_is, 0);
-                if(I != GrB_ALL) {
-                    free(I);
-                }
+                (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
 
                 return res;
                 }

--- a/graphblas-java/src/main/templates/c/unsafe_gen.c.ftl
+++ b/graphblas-java/src/main/templates/c/unsafe_gen.c.ftl
@@ -57,6 +57,10 @@ long check_grb_error(GrB_Info info);
                 GrB_Index * java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
+                if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long res = check_grb_error(GrB_Matrix_extractTuples_${prop.grb_type}(java_is, java_js, elms, &nvals, A));
 
                 // JNI tell Java we're done
@@ -74,6 +78,10 @@ long check_grb_error(GrB_Info info);
 
                 j${prop.java_type} *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
 
                 long res = check_grb_error(GrB_Vector_extractTuples_${prop.grb_type}(java_is, elms, &nvals, A));
 
@@ -93,6 +101,10 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
+                if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long res = check_grb_error(GrB_Matrix_build_${prop.grb_type}(A, java_is, java_js, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
@@ -109,6 +121,10 @@ long check_grb_error(GrB_Info info);
 
                 j${prop.java_type} *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL || elms == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
 
                 long res = check_grb_error(GrB_Vector_build_${prop.grb_type}(A, java_is, elms, nvals, dup));
                 // JNI tell Java we're done
@@ -153,12 +169,16 @@ long check_grb_error(GrB_Info info);
                 // NON OPTIONAL STUFF
                 GrB_Vector w = (GrB_Vector) (*env)->GetDirectBufferAddress(env, vec);
 
-                GrB_Index* I = NULL;
                 GrB_Index grb_ni = (GrB_Index) ni;
                 jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+
+                if (java_is == NULL) {
+                    return GrB_OUT_OF_MEMORY;
+                }
+
                 long java_min = -9223372036854775808;
 
-                I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
+                GrB_Index *I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
                 // OPTIONAL STUFF
                 GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;

--- a/graphblas-java/src/main/templates/c/unsafe_gen.c.ftl
+++ b/graphblas-java/src/main/templates/c/unsafe_gen.c.ftl
@@ -166,12 +166,7 @@ long check_grb_error(GrB_Info info);
                 jlong * java_is = (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 long java_min = -9223372036854775808;
 
-                if (java_is[0] == java_min) {
-                    I = GrB_ALL;
-                }
-                else {
-                    I = (GrB_Index*) java_is;
-                }
+                I = java_is[0] != java_min ? (GrB_Index*) java_is : GrB_ALL;
 
                 // OPTIONAL STUFF
                 GrB_BinaryOp acc = accum != NULL ? (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, accum): NULL;

--- a/graphblas-java/src/main/templates/c/unsafe_gen.c.ftl
+++ b/graphblas-java/src/main/templates/c/unsafe_gen.c.ftl
@@ -93,7 +93,7 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
-                long res = GrB_Matrix_build_${prop.grb_type}(A, java_is, java_js, elms, nvals, dup);
+                long res = check_grb_error(GrB_Matrix_build_${prop.grb_type}(A, java_is, java_js, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
                 (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
@@ -110,7 +110,7 @@ long check_grb_error(GrB_Info info);
                 j${prop.java_type} *elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
-                long res = GrB_Vector_build_${prop.grb_type}(A, java_is, elms, nvals, dup);
+                long res = check_grb_error(GrB_Vector_build_${prop.grb_type}(A, java_is, elms, nvals, dup));
                 // JNI tell Java we're done
                 (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
                 (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);

--- a/graphblas-java/src/main/templates/c/unsafe_gen.c.ftl
+++ b/graphblas-java/src/main/templates/c/unsafe_gen.c.ftl
@@ -58,6 +58,18 @@ long check_grb_error(GrB_Info info);
                 GrB_Index * java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
+                    if(java_js != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -80,6 +92,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index *java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 if (java_is == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -102,6 +122,18 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 if (java_is == NULL || java_js == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
+                    if(java_js != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, js, java_js, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 
@@ -123,6 +155,14 @@ long check_grb_error(GrB_Info info);
                 GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
 
                 if (java_is == NULL || elms == NULL) {
+                    if(java_is != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, is, java_is, 0);
+                    }
+
+                    if(elms != NULL) {
+                        (*env)->ReleasePrimitiveArrayCritical(env, vs, elms, 0);
+                    }
+
                     return GrB_OUT_OF_MEMORY;
                 }
 

--- a/graphblas-java/src/main/templates/c/unsafe_gen.c.ftl
+++ b/graphblas-java/src/main/templates/c/unsafe_gen.c.ftl
@@ -89,17 +89,9 @@ long check_grb_error(GrB_Info info);
                 GrB_BinaryOp dup = (GrB_BinaryOp) (*env)->GetDirectBufferAddress(env, dupOp);
                 GrB_Index nvals = (GrB_Index)n;
 
-                bool cV;
-                bool cI;
-                bool cJ;
-
-                j${prop.java_type}* elms = (*env)->GetPrimitiveArrayCritical(env, vs, &cV);
-                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, &cI);
-                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, &cJ);
-
-                printf("Values copied? %d \n", cV) ;
-                printf("Is copied? %d \n", cI) ;
-                printf("Js copied? %d \n", cJ) ;
+                j${prop.java_type}* elms = (*env)->GetPrimitiveArrayCritical(env, vs, NULL);
+                GrB_Index* java_is = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, is, NULL);
+                GrB_Index* java_js = (GrB_Index*) (*env)->GetPrimitiveArrayCritical(env, js, NULL);
 
                 long res = GrB_Matrix_build_${prop.grb_type}(A, java_is, java_js, elms, nvals, dup);
                 // JNI tell Java we're done


### PR DESCRIPTION
For once I casted the pointer from (jlong*) to (GrB_Index*) -> avoid copying into a seperate C-array.
As a second step I potentially avoided copying the java array via using `GetPrimitiveArrayCritical` (in my test it worked, but might be jvm dependend?).
However using `GetPrimitiveArrayCritical` might be dangerous (see https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#GetPrimitiveArrayCritical_ReleasePrimitiveArrayCritical or https://shipilev.net/jvm/anatomy-quarks/9-jni-critical-gclocker/).
Maybe it is an idea to have a global option, whether to use `GetPrimitiveArrayCritical` or `GetLongArray`.

On the plus side I could simplify the c-code.

.. also 2 minor things like adding missing status checks and fixing a wrong pointer cast (which I could also cherry pick to another PR)